### PR TITLE
Feature/0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### 0.4.0 (28-05-2020)
+#### Bugs
+* Podman used the wrong base dir for building container images
+* When TLS Verify is not set, this sometimes caused an '... takes only 1 argument' error, due to an empty subcommand being passed.
+
+#### Improvements
+* Changed the log line that says 'Initializing image configurations.' to debug.
+
 ### 0.3.0 (27-05-2020)
 #### Bugs
 * AuthenticationService now checks the default credential file based on the XDG_RUNTIME_DIR environment variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Improvements
 * Changed the log line that says 'Initializing image configurations.' to debug.
+* Explicitly set `dockerFileDir` to value of `${project.baseDir}` rather then `new File(".")`
 
 ### 0.3.0 (27-05-2020)
 #### Bugs

--- a/src/main/java/nl/lexemmens/podman/AbstractPodmanMojo.java
+++ b/src/main/java/nl/lexemmens/podman/AbstractPodmanMojo.java
@@ -86,7 +86,7 @@ public abstract class AbstractPodmanMojo extends AbstractMojo {
     }
 
     private void initImageConfigurations() throws MojoExecutionException {
-        getLog().info("Initializing image configurations.");
+        getLog().debug("Initializing image configurations.");
         for (ImageConfiguration image : images) {
             image.initAndValidate(project, getLog());
         }

--- a/src/main/java/nl/lexemmens/podman/image/BuildImageConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/image/BuildImageConfiguration.java
@@ -148,6 +148,16 @@ public class BuildImageConfiguration {
     }
 
     /**
+     * Returns the location of the raw Dockerfile. This location is used
+     * as the context dir when running podman.
+     *
+     * @return The location of the raw Dockerfile as a File.
+     */
+    public File getDockerFileDir() {
+        return dockerFileDir;
+    }
+
+    /**
      * Validates this class by giving all null properties a default value.
      *
      * @param project The MavenProject used to derive some of the default values from.

--- a/src/main/java/nl/lexemmens/podman/image/BuildImageConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/image/BuildImageConfiguration.java
@@ -170,7 +170,7 @@ public class BuildImageConfiguration {
         }
 
         if (dockerFileDir == null) {
-            dockerFileDir = new File("");
+            dockerFileDir = project.getBasedir();
         }
 
         if (labels == null) {

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -14,6 +14,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import static nl.lexemmens.podman.enumeration.TlsVerify.NOT_SPECIFIED;
+
 /**
  * Class that allows very specific execution of Podman related commands.
  */
@@ -170,16 +172,19 @@ public class PodmanExecutorService {
         fullCommand.add(PodmanCommand.PODMAN.getCommand());
         fullCommand.add(podmanCommand.getCommand());
 
-        if (!PodmanCommand.TAG.equals(podmanCommand)
-                && !PodmanCommand.SAVE.equals(podmanCommand)
-                && !PodmanCommand.RMI.equals(podmanCommand)
-                && tlsVerify != null) {
+        if (isTlsSupported(podmanCommand) && tlsVerify != null && !NOT_SPECIFIED.equals(tlsVerify)) {
             fullCommand.add(tlsVerify.getCommand());
         }
 
         fullCommand.addAll(subCommands);
 
         return fullCommand;
+    }
+
+    private boolean isTlsSupported(PodmanCommand podmanCommand) {
+        return !PodmanCommand.TAG.equals(podmanCommand)
+                && !PodmanCommand.SAVE.equals(podmanCommand)
+                && !PodmanCommand.RMI.equals(podmanCommand);
     }
 
     private List<String> runCommand(boolean redirectError, PodmanCommand command, List<String> subCommands) throws MojoExecutionException {

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -62,7 +62,7 @@ public class PodmanExecutorService {
         subCommand.add(NO_CACHE_CMD + image.getBuild().isNoCache());
         subCommand.add(".");
 
-        List<String> processOutput = runCommand(image.getBuild().getOutputDirectory(), false, PodmanCommand.BUILD, subCommand);
+        List<String> processOutput = runCommand(false, PodmanCommand.BUILD, subCommand);
         return processOutput.get(processOutput.size() - 1);
     }
 
@@ -114,7 +114,7 @@ public class PodmanExecutorService {
     public void push(String fullImageName) throws MojoExecutionException {
         // Apparently, actually pushing the blobs to a registry causes some output on stderr.
         // Ignore output
-        runCommand(BASE_DIR, false, PodmanCommand.PUSH, List.of(fullImageName));
+        runCommand(false, PodmanCommand.PUSH, List.of(fullImageName));
     }
 
     /**
@@ -182,11 +182,11 @@ public class PodmanExecutorService {
         return fullCommand;
     }
 
-    private List<String> runCommand(File baseDir, boolean redirectError, PodmanCommand command, List<String> subCommands) throws MojoExecutionException {
-        String msg = String.format("Executing command %s from basedir %s", StringUtils.join(command, " "), baseDir);
+    private List<String> runCommand(boolean redirectError, PodmanCommand command, List<String> subCommands) throws MojoExecutionException {
+        String msg = String.format("Executing command %s from basedir %s", StringUtils.join(command, " "), BASE_DIR);
         log.debug(msg);
         ProcessExecutor processExecutor = new ProcessExecutor()
-                .directory(baseDir)
+                .directory(BASE_DIR)
                 .command(decorateCommands(command, subCommands))
                 .readOutput(true)
                 .redirectOutput(Slf4jStream.of(getClass().getSimpleName()).asInfo())
@@ -203,6 +203,6 @@ public class PodmanExecutorService {
 
     private void runCommand(PodmanCommand command, List<String> subCommands) throws MojoExecutionException {
         // Ignore output
-        runCommand(BASE_DIR, true, command, subCommands);
+        runCommand(true, command, subCommands);
     }
 }

--- a/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.isA;
@@ -244,6 +245,7 @@ public class BuildMojoTest extends AbstractMojoTest {
         configureMojo(image, true, false, false, false);
 
         when(mavenProject.getBuild()).thenReturn(build);
+        when(mavenProject.getBasedir()).thenReturn(new File("."));
         when(build.getDirectory()).thenReturn("target");
         when(serviceHubFactory.createServiceHub(isA(Log.class), isA(MavenProject.class), isA(MavenFileFilter.class), isA(TlsVerify.class), isA(Settings.class), isA(SettingsDecrypter.class))).thenReturn(serviceHub);
 

--- a/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
+++ b/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
@@ -21,8 +21,7 @@ import org.zeroturnaround.exec.ProcessExecutor;
 import java.util.ArrayList;
 import java.util.List;
 
-import static nl.lexemmens.podman.enumeration.TlsVerify.FALSE;
-import static nl.lexemmens.podman.enumeration.TlsVerify.TRUE;
+import static nl.lexemmens.podman.enumeration.TlsVerify.*;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -57,6 +56,15 @@ public class PodmanExecutorServiceTest {
         podmanExecutorService.login("registry.example.com", "username", "password");
 
         Assertions.assertEquals("podman login --tls-verify=false registry.example.com -u username -p password", delegate.getCommandAsString());
+    }
+
+    @Test
+    public void testLoginWithTlsNotSpecified() throws MojoExecutionException {
+        InterceptorCommandExecutorDelegate delegate = new InterceptorCommandExecutorDelegate();
+        podmanExecutorService = new PodmanExecutorService(log, NOT_SPECIFIED, delegate);
+        podmanExecutorService.login("registry.example.com", "username", "password");
+
+        Assertions.assertEquals("podman login registry.example.com -u username -p password", delegate.getCommandAsString());
     }
 
     @Test


### PR DESCRIPTION
#### Bugs
* Podman used the wrong base dir for building container images
* When TLS Verify is not set, this sometimes caused an '... takes only 1 argument' error, due to an empty subcommand being passed.

#### Improvements
* Changed the log line that says 'Initializing image configurations.' to debug.
* Explicitly set `dockerFileDir` to value of `${project.baseDir}` rather then `new File(".")`