### PR TITLE
Added option to configure Podman's --runroot option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 0.9.0 (22-09-2020)
+#### Improvements
+* Added configuration of the `--runroot` setting, which is used by Podman to store its state information.
+
 ### 0.8.0 (xx-09-2020)
 #### Improvements
 * Added clean phase that allows cleaning up the local storage. This only works when the root storage location is configured in the pom file to prevent accidentally deleting unrelated files.

--- a/src/main/java/nl/lexemmens/podman/image/PodmanConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/image/PodmanConfiguration.java
@@ -22,10 +22,22 @@ public class PodmanConfiguration {
     protected TlsVerify tlsVerify;
 
     /**
-     * Podman's root directory
+     * Podman's root directory.
+     * <p>
+     * Storage root dir in which data, including images, is stored (default: “/var/lib/containers/storage” for UID 0,
+     * “$HOME/.local/share/containers/storage” for other users). Default root dir configured in /etc/containers/storage.conf.
      */
     @Parameter(property = "podman.root")
     protected File root;
+
+    /**
+     * Podman's root directory for state information.
+     * <p>
+     * Storage state directory where all state information is stored (default: “/var/run/containers/storage” for UID 0,
+     * “/var/run/user/$UID/run” for other users). Default state dir configured in /etc/containers/storage.conf.
+     */
+    @Parameter(property = "podman.run.root")
+    protected File runRoot;
 
     /**
      * Constructor
@@ -53,6 +65,15 @@ public class PodmanConfiguration {
     }
 
     /**
+     * Returns the runroot directory that Podman should use for saving state information
+     *
+     * @return Podman's runroot directory
+     */
+    public File getRunRoot() {
+        return runRoot;
+    }
+
+    /**
      * Validates and initializes this configuration
      *
      * @param log Access to Maven's log system for informational purposes.
@@ -69,7 +90,13 @@ public class PodmanConfiguration {
         if (root == null) {
             log.debug("Using Podman's default settings for --root.");
         } else {
-            log.info("Setting Podman's root directory to: " + root.getAbsolutePath());
+            log.info("Setting Podman's 'root' directory to: " + root.getAbsolutePath());
+        }
+
+        if (runRoot == null) {
+            log.debug("Using Podman's default settings for --runroot.");
+        } else {
+            log.info("Setting Podman's 'runroot' directory to: " + runRoot.getAbsolutePath());
         }
     }
 }

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -28,6 +28,7 @@ public class PodmanExecutorService {
     private static final String DOCKERFILE_CMD = "--file=";
     private static final String NO_CACHE_CMD = "--no-cache=";
     private static final String ROOT_CMD = "--root=";
+    private static final String RUNROOT_CMD = "--runroot=";
 
     private static final File BASE_DIR = new File(".");
 
@@ -35,6 +36,7 @@ public class PodmanExecutorService {
     private final TlsVerify tlsVerify;
     private final CommandExecutorDelegate delegate;
     private final File podmanRoot;
+    private final File podmanRunRoot;
 
 
     /**
@@ -49,6 +51,7 @@ public class PodmanExecutorService {
         this.delegate = delegate;
         this.tlsVerify = podmanConfig.getTlsVerify();
         this.podmanRoot = podmanConfig.getRoot();
+        this.podmanRunRoot = podmanConfig.getRunRoot();
     }
 
     /**
@@ -181,6 +184,10 @@ public class PodmanExecutorService {
         // Path to the root directory in which data, including images, is stored. Must be *before* build, push or any other operation
         if (podmanRoot != null) {
             fullCommand.add(ROOT_CMD + podmanRoot.getAbsolutePath());
+        }
+
+        if (podmanRunRoot != null) {
+            fullCommand.add(RUNROOT_CMD + podmanRunRoot.getAbsolutePath());
         }
 
         fullCommand.add(podmanCommand.getCommand());

--- a/src/test/java/nl/lexemmens/podman/image/TestPodmanConfigurationBuilder.java
+++ b/src/test/java/nl/lexemmens/podman/image/TestPodmanConfigurationBuilder.java
@@ -24,6 +24,11 @@ public class TestPodmanConfigurationBuilder {
         return this;
     }
 
+    public TestPodmanConfigurationBuilder setRunRoot(File runRoot) {
+        podman.runRoot = runRoot;
+        return this;
+    }
+
     public TestPodmanConfigurationBuilder initAndValidate(Log log) throws MojoExecutionException {
         podman.initAndValidate(log);
         return this;

--- a/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
+++ b/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
@@ -228,6 +228,61 @@ public class PodmanExecutorServiceTest {
                 delegate.getCommandAsString());
     }
 
+    @Test
+    public void testBuildWithCustomRunRootDir() throws MojoExecutionException {
+        when(mavenProject.getBuild()).thenReturn(build);
+        when(build.getDirectory()).thenReturn("target");
+
+        PodmanConfiguration podmanConfig = new TestPodmanConfigurationBuilder()
+                .setTlsVerify(TRUE)
+                .setRunRoot(new File("/some/custom/runroot/dir"))
+                .initAndValidate(log)
+                .build();
+
+        ImageConfiguration image = new TestImageConfigurationBuilder("test_image")
+                .setDockerfileDir("src/test/resources")
+                .setFormat(OCI)
+                .initAndValidate(mavenProject, log)
+                .build();
+
+        String sampleImageHash = "this_would_normally_be_an_image_hash";
+        InterceptorCommandExecutorDelegate delegate = new InterceptorCommandExecutorDelegate(List.of(sampleImageHash));
+        podmanExecutorService = new PodmanExecutorService(log, podmanConfig, delegate);
+
+        podmanExecutorService.build(image);
+
+        Assertions.assertEquals("podman --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetDockerfile() + " --no-cache=false .",
+                delegate.getCommandAsString());
+    }
+
+    @Test
+    public void testBuildWithCustomRootAndRunRootDir() throws MojoExecutionException {
+        when(mavenProject.getBuild()).thenReturn(build);
+        when(build.getDirectory()).thenReturn("target");
+
+        PodmanConfiguration podmanConfig = new TestPodmanConfigurationBuilder()
+                .setTlsVerify(TRUE)
+                .setRoot(new File("/some/custom/root/dir"))
+                .setRunRoot(new File("/some/custom/runroot/dir"))
+                .initAndValidate(log)
+                .build();
+
+        ImageConfiguration image = new TestImageConfigurationBuilder("test_image")
+                .setDockerfileDir("src/test/resources")
+                .setFormat(OCI)
+                .initAndValidate(mavenProject, log)
+                .build();
+
+        String sampleImageHash = "this_would_normally_be_an_image_hash";
+        InterceptorCommandExecutorDelegate delegate = new InterceptorCommandExecutorDelegate(List.of(sampleImageHash));
+        podmanExecutorService = new PodmanExecutorService(log, podmanConfig, delegate);
+
+        podmanExecutorService.build(image);
+
+        Assertions.assertEquals("podman --root=/some/custom/root/dir --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetDockerfile() + " --no-cache=false .",
+                delegate.getCommandAsString());
+    }
+
 
     private static class InterceptorCommandExecutorDelegate implements CommandExecutorDelegate {
 


### PR DESCRIPTION
The option `--runroot` is used to store state information.