### PR TITLE
introduce the `--pull` option mirroring `--no-cache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+### 1.4.0 (25-11-2020)
+#### Improvements
+* (#26) Introduced `pull` option in build configuration to control whether an image should be pulled. [More information](https://www.redhat.com/sysadmin/podman-image-pulling). Thanks to [Christopher J. Uwe](https://github.com/cruwe).
+
 ### 1.3.0 (18-11-2020)
 #### Improvements
 * When debug is enabled, Podman version information will now be printed.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The example in XML below lists all the other configuration options that are poss
                     <noCache>true</noCache>
                     <containerFile>Containerfile</containerFile>
                     <containerFileDir>path/to/a/directory</containerFileDir>
+                    <pull>true</pull>
 
                     <tagWithMavenProjectVersion>false</tagWithMavenProjectVersion>
                     <createLatestTag>false</createLatestTag>
@@ -189,6 +190,7 @@ The tables below explains the configuration options for container images that we
 |--------------------------|---------|----------|--------------------|-------------|
 | name                     | String  | Y        | -                  | The name of the container image without the registry or tag. May contain a repository. Example: `some/repo/image`. [Docker naming conventions](https://docs.docker.com/engine/reference/commandline/tag/) apply. |
 | noCache                  | Boolean | N        | false              | Do not use cache when building the image |
+| pull                     | Boolean | N        | true               | Controls whether the image should be pulled if non-existant in local storage |
 | containerFile               | String  | N        | Containerfile         | Allows using a Containerfile that is named differently |
 | containerFileDir            | String  | N        | Current Module Dir | Specifies in which directory to find the Containerfile |
 | tagAsMavenProjectVersion | Boolean | N        | false              | When set to true, the container image will automatically be tagged with the version of the Maven project. Note that a container can receive one or more tags whilst maintaining the same name. |

--- a/src/main/java/nl/lexemmens/podman/image/BuildImageConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/image/BuildImageConfiguration.java
@@ -43,7 +43,7 @@ public class BuildImageConfiguration {
      * always be build on the latest base.
      */
     @Parameter
-    protected boolean pull;
+    protected Boolean pull;
 
 
     /**
@@ -282,6 +282,10 @@ public class BuildImageConfiguration {
 
         if (format == null) {
             format = OCI;
+        }
+
+        if (pull == null) {
+            pull = true;
         }
 
         this.mavenProjectVersion = project.getVersion();

--- a/src/main/java/nl/lexemmens/podman/image/BuildImageConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/image/BuildImageConfiguration.java
@@ -39,6 +39,14 @@ public class BuildImageConfiguration {
     protected boolean noCache;
 
     /**
+     * Configures whether from-images should be pulled so that the image will
+     * always be build on the latest base.
+     */
+    @Parameter
+    protected boolean pull;
+
+
+    /**
      * Array consisting of one or more tags to attach to a container image.
      * Tags will be appended at the end of the image name
      */
@@ -123,6 +131,15 @@ public class BuildImageConfiguration {
      */
     public boolean isNoCache() {
         return noCache;
+    }
+
+    /**
+     * Returns if the --pull property should be used
+     *
+     * @return When set to true, podman will build with --pull
+     */
+    public boolean isPull() {
+        return pull;
     }
 
     /**

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -28,6 +28,7 @@ public class PodmanExecutorService {
     private static final String OUTPUT_CMD = "--output";
     private static final String CONTAINERFILE_CMD = "--file=";
     private static final String NO_CACHE_CMD = "--no-cache=";
+    private static final String PULL_CMD = "--pull=";
     private static final String ROOT_CMD = "--root=";
     private static final String RUNROOT_CMD = "--runroot=";
 
@@ -75,6 +76,7 @@ public class PodmanExecutorService {
         subCommand.add(BUILD_FORMAT_CMD + image.getBuild().getFormat().getValue());
         subCommand.add(CONTAINERFILE_CMD + image.getBuild().getTargetContainerFile());
         subCommand.add(NO_CACHE_CMD + image.getBuild().isNoCache());
+        subCommand.add(PULL_CMD + image.getBuild().isPull());
         subCommand.add(".");
 
         return runCommand(podmanRunDirectory, false, PodmanCommand.BUILD, subCommand);

--- a/src/test/java/nl/lexemmens/podman/image/TestImageConfigurationBuilder.java
+++ b/src/test/java/nl/lexemmens/podman/image/TestImageConfigurationBuilder.java
@@ -26,6 +26,11 @@ public class TestImageConfigurationBuilder {
         return this;
     }
 
+    public TestImageConfigurationBuilder setPull(boolean pull) {
+        image.build.pull = pull;
+        return this;
+    }
+
     public TestImageConfigurationBuilder setLabels(Map<String, String> labels) {
         image.build.labels = labels;
         return this;

--- a/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
+++ b/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
@@ -202,7 +202,7 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=false .",
+        Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true .",
                 delegate.getCommandAsString());
     }
 
@@ -224,7 +224,7 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman build --tls-verify=true --format=docker --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=false .",
+        Assertions.assertEquals("podman build --tls-verify=true --format=docker --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true .",
                 delegate.getCommandAsString());
     }
 
@@ -251,7 +251,7 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman --root=/some/custom/root/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=false .",
+        Assertions.assertEquals("podman --root=/some/custom/root/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true .",
                 delegate.getCommandAsString());
     }
 
@@ -278,7 +278,7 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=false .",
+        Assertions.assertEquals("podman --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true .",
                 delegate.getCommandAsString());
     }
 
@@ -306,7 +306,7 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman --root=/some/custom/root/dir --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=false .",
+        Assertions.assertEquals("podman --root=/some/custom/root/dir --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true .",
                 delegate.getCommandAsString());
     }
 

--- a/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
+++ b/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
@@ -202,7 +202,7 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false .",
+        Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=false .",
                 delegate.getCommandAsString());
     }
 
@@ -224,7 +224,7 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman build --tls-verify=true --format=docker --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false .",
+        Assertions.assertEquals("podman build --tls-verify=true --format=docker --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=false .",
                 delegate.getCommandAsString());
     }
 
@@ -251,7 +251,7 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman --root=/some/custom/root/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false .",
+        Assertions.assertEquals("podman --root=/some/custom/root/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=false .",
                 delegate.getCommandAsString());
     }
 
@@ -278,7 +278,7 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false .",
+        Assertions.assertEquals("podman --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=false .",
                 delegate.getCommandAsString());
     }
 
@@ -306,7 +306,7 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman --root=/some/custom/root/dir --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false .",
+        Assertions.assertEquals("podman --root=/some/custom/root/dir --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=false .",
                 delegate.getCommandAsString());
     }
 


### PR DESCRIPTION
First, thank you very much for developing this plugin and allowing the public to profit from your work.

For the plugin to selectively force pull the `FROM` image, I mirrored the config forthe related `--no-cache`. I hope I do not mess up your intended organization.

Thanks again and cheers!
