### PR TITLE
Changed the algorithm for multistage image hash detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+### 1.5.0 (09-02-2020)
+#### Bugs
+* ([#28](https://github.com/lexemmens/podman-maven-plugin/issues/28)) - Changed algorithm for image hash detection when using multistage containerfiles to use lookahead instead of look back. 
+
 ### 1.4.0 (25-11-2020)
 #### Improvements
 * ([#26](https://github.com/lexemmens/podman-maven-plugin/pull/26)) Introduced `pull` option in build configuration to control whether an image should be pulled. [More information](https://www.redhat.com/sysadmin/podman-image-pulling). Thanks to [Christopher J. Uwe](https://github.com/cruwe).

--- a/src/main/java/nl/lexemmens/podman/BuildMojo.java
+++ b/src/main/java/nl/lexemmens/podman/BuildMojo.java
@@ -104,7 +104,7 @@ public class BuildMojo extends AbstractPodmanMojo {
             Matcher stageMatcher = stagePattern.matcher(currentLine);
             boolean currentLineDefinesStage = stageMatcher.find();
 
-            getLog().debug("Processing line: '" + currentLine + "', defines stage: " + currentLineDefinesStage);
+            getLog().debug("Processing line: '" + currentLine + "', matches: " + currentLineDefinesStage);
 
             // Check if the next line contains a hash
             Optional<String> imageHashOptional = retrieveImageHashFromLine(nextLine);
@@ -121,7 +121,7 @@ public class BuildMojo extends AbstractPodmanMojo {
                 currentStage = stageMatcher.group(3);
                 lastKnownImageHash = null;
 
-                getLog().info("Found stage in Containerfile: " + currentStage);
+                getLog().debug("Found stage in Containerfile: " + currentStage);
             } else if(currentLine.startsWith("STEP") && imageHashOptional.isPresent()) {
                 lastKnownImageHash = imageHashOptional.get();
                 getLog().debug("Stage " + currentStage + ", current image hash: " + lastKnownImageHash);

--- a/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
@@ -413,14 +413,14 @@ public class BuildMojoTest extends AbstractMojoTest {
         verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false"));
 
         // Verify stage detection
-        verify(log, times(1)).debug(Mockito.eq("Initial detection of a stage in Containerfile. Stage: base"));
-        verify(log, times(1)).debug(Mockito.eq("Found new stage in Containerfile: phase"));
-        verify(log, times(1)).debug(Mockito.eq("Found new stage in Containerfile: phase2"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: base"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase2"));
 
         // Verify hashes for stages
-        verify(log, times(1)).info(Mockito.eq("Found image hash 7e72c870614 for stage base"));
-        verify(log, times(1)).info(Mockito.eq("Found image hash 7f55eab001a for stage phase"));
-        verify(log, times(1)).info(Mockito.eq("Using image hash of final image (d2efc6645cbb6ea012f8adcaaab6b03ef847dd3d2b4fa418ca4cde57eff28a7f) for stage: phase2"));
+        verify(log, times(1)).info(Mockito.eq("Final image for stage base is: 7e72c870614"));
+        verify(log, times(1)).info(Mockito.eq("Final image for stage phase is: 7f55eab001a"));
+        verify(log, times(1)).info(Mockito.eq("Final image for stage phase2 is: d2efc6645cb"));
 
         // Verify tagging image
         verify(log, times(1)).info(Mockito.eq("Tagging container image d2efc6645cbb6ea012f8adcaaab6b03ef847dd3d2b4fa418ca4cde57eff28a7f as registry.example.com/sample:1.0.0"));
@@ -469,9 +469,9 @@ public class BuildMojoTest extends AbstractMojoTest {
         verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false"));
 
         // Verify stage detection
-        verify(log, times(1)).info(Mockito.eq("Found stage in Containerfile: base"));
-        verify(log, times(1)).info(Mockito.eq("Found stage in Containerfile: phase"));
-        verify(log, times(1)).info(Mockito.eq("Found stage in Containerfile: phase2"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: base"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase2"));
 
         // Verify hashes for stages
         verify(log, times(1)).info(Mockito.eq("Final image for stage base is: 7e72c870614"));
@@ -529,9 +529,9 @@ public class BuildMojoTest extends AbstractMojoTest {
         verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false"));
 
         // Verify stage detection
-        verify(log, times(1)).info(Mockito.eq("Found stage in Containerfile: base"));
-        verify(log, times(1)).info(Mockito.eq("Found stage in Containerfile: phase"));
-        verify(log, times(1)).info(Mockito.eq("Found stage in Containerfile: phase2"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: base"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase2"));
 
         // Verify hashes for stages
         verify(log, times(1)).info(Mockito.eq("Final image for stage base is: 7e72c870614"));
@@ -588,9 +588,9 @@ public class BuildMojoTest extends AbstractMojoTest {
         verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false"));
 
         // Verify stage detection
-        verify(log, times(1)).info(Mockito.eq("Found stage in Containerfile: base"));
-        verify(log, times(1)).info(Mockito.eq("Found stage in Containerfile: phase"));
-        verify(log, times(1)).info(Mockito.eq("Found stage in Containerfile: phase2"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: base"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase"));
+        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase2"));
 
         // Verify hashes for stages
         verify(log, times(1)).info(Mockito.eq("Final image for stage base is: 823ed30df4abf7574498d5f766b0ebf70793d73a99fc4220dda200c5131b60ce"));

--- a/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
@@ -66,7 +66,7 @@ public class BuildMojoTest extends AbstractMojoTest {
 
         buildMojo.execute();
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Podman actions are skipped."));
+        verify(log, Mockito.times(1)).info("Podman actions are skipped.");
     }
 
     @Test
@@ -82,7 +82,7 @@ public class BuildMojoTest extends AbstractMojoTest {
 
         buildMojo.execute();
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Building container images is skipped."));
+        verify(log, Mockito.times(1)).info("Building container images is skipped.");
     }
 
     @Test
@@ -120,7 +120,7 @@ public class BuildMojoTest extends AbstractMojoTest {
 
         buildMojo.execute();
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Tagging container images is skipped."));
+        verify(log, Mockito.times(1)).info("Tagging container images is skipped.");
         verify(mavenFileFilter, Mockito.times(1)).copyFile(isA(MavenFileFilterRequest.class));
         verify(podmanExecutorService, times(1)).build(isA(ImageConfiguration.class));
     }
@@ -141,7 +141,7 @@ public class BuildMojoTest extends AbstractMojoTest {
 
         Assertions.assertDoesNotThrow(() -> buildMojo.execute());
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Tagging container images is skipped."));
+        verify(log, Mockito.times(1)).info("Tagging container images is skipped.");
         verify(mavenFileFilter, Mockito.times(1)).copyFile(isA(MavenFileFilterRequest.class));
         verify(podmanExecutorService, times(1)).build(isA(ImageConfiguration.class));
     }
@@ -164,7 +164,7 @@ public class BuildMojoTest extends AbstractMojoTest {
 
         buildMojo.execute();
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Tagging container images is skipped."));
+        verify(log, Mockito.times(1)).info("Tagging container images is skipped.");
         verify(mavenFileFilter, Mockito.times(1)).copyFile(isA(MavenFileFilterRequest.class));
         verify(podmanExecutorService, times(1)).build(isA(ImageConfiguration.class));
     }
@@ -186,8 +186,8 @@ public class BuildMojoTest extends AbstractMojoTest {
 
         buildMojo.execute();
 
-        verify(log, Mockito.times(0)).info(Mockito.eq("Tagging container images is skipped."));
-        verify(log, Mockito.times(1)).info(Mockito.eq("No tags specified. Skipping tagging of container images."));
+        verify(log, Mockito.times(0)).info("Tagging container images is skipped.");
+        verify(log, Mockito.times(1)).info("No tags specified. Skipping tagging of container images.");
         verify(mavenFileFilter, Mockito.times(1)).copyFile(isA(MavenFileFilterRequest.class));
         verify(podmanExecutorService, times(1)).build(isA(ImageConfiguration.class));
     }
@@ -210,8 +210,8 @@ public class BuildMojoTest extends AbstractMojoTest {
 
         buildMojo.execute();
 
-        verify(log, Mockito.times(0)).info(Mockito.eq("Tagging container images is skipped."));
-        verify(log, Mockito.times(1)).info(Mockito.eq("No tags specified. Skipping tagging of container images."));
+        verify(log, Mockito.times(0)).info("Tagging container images is skipped.");
+        verify(log, Mockito.times(1)).info("No tags specified. Skipping tagging of container images.");
         verify(mavenFileFilter, Mockito.times(1)).copyFile(isA(MavenFileFilterRequest.class));
         verify(podmanExecutorService, times(1)).build(isA(ImageConfiguration.class));
     }
@@ -238,12 +238,12 @@ public class BuildMojoTest extends AbstractMojoTest {
 
         buildMojo.execute();
 
-        verify(log, Mockito.times(0)).info(Mockito.eq("Tagging container images is skipped."));
-        verify(log, Mockito.times(0)).info(Mockito.eq("No tags specified. Skipping tagging of container images."));
-        verify(log, Mockito.times(1)).info(Mockito.eq("Tagging container image " + imageHash + " as " + expectedFullImageName));
+        verify(log, Mockito.times(0)).info("Tagging container images is skipped.");
+        verify(log, Mockito.times(0)).info("No tags specified. Skipping tagging of container images.");
+        verify(log, Mockito.times(1)).info("Tagging container image " + imageHash + " as " + expectedFullImageName);
         verify(mavenFileFilter, Mockito.times(1)).copyFile(isA(MavenFileFilterRequest.class));
         verify(podmanExecutorService, times(1)).build(isA(ImageConfiguration.class));
-        verify(podmanExecutorService, times(1)).tag(eq(imageHash), eq(expectedFullImageName));
+        verify(podmanExecutorService, times(1)).tag(imageHash, expectedFullImageName);
     }
 
     @Test
@@ -268,13 +268,13 @@ public class BuildMojoTest extends AbstractMojoTest {
 
         buildMojo.execute();
 
-        verify(log, Mockito.times(0)).info(Mockito.eq("Tagging container images is skipped."));
-        verify(log, Mockito.times(0)).info(Mockito.eq("No tags specified. Skipping tagging of container images."));
-        verify(log, Mockito.times(1)).info(Mockito.eq("Tagging container image " + imageHash + " as registry.example.com/sample:latest"));
+        verify(log, Mockito.times(0)).info("Tagging container images is skipped.");
+        verify(log, Mockito.times(0)).info("No tags specified. Skipping tagging of container images.");
+        verify(log, Mockito.times(1)).info("Tagging container image " + imageHash + " as registry.example.com/sample:latest");
         verify(mavenFileFilter, Mockito.times(1)).copyFile(isA(MavenFileFilterRequest.class));
 
         verify(podmanExecutorService, times(1)).build(isA(ImageConfiguration.class));
-        verify(podmanExecutorService, times(1)).tag(eq(imageHash), eq(expectedFullImageName));
+        verify(podmanExecutorService, times(1)).tag(imageHash, expectedFullImageName);
     }
 
     @Test
@@ -312,8 +312,8 @@ public class BuildMojoTest extends AbstractMojoTest {
         when(build.getDirectory()).thenReturn("target");
 
         Assertions.assertDoesNotThrow(buildMojo::execute);
-        verify(log, Mockito.times(1)).warn(Mockito.eq("No Containerfile was found at " + targetLocationAsString + File.separator + "Containerfile, however this will be ignored due to current plugin configuration."));
-        verify(log, Mockito.times(1)).warn(Mockito.eq("Skipping build of container image with name sample. Configuration is not valid for this module!"));
+        verify(log, Mockito.times(1)).warn("No Containerfile was found at " + targetLocationAsString + File.separator + "Containerfile, however this will be ignored due to current plugin configuration.");
+        verify(log, Mockito.times(1)).warn("Skipping build of container image with name sample. Configuration is not valid for this module!");
     }
 
     @Test
@@ -357,7 +357,7 @@ public class BuildMojoTest extends AbstractMojoTest {
         // No Containerfile present at root level
         Assertions.assertThrows(MojoExecutionException.class, buildMojo::execute);
 
-        verify(log, times(1)).info(Mockito.eq("Setting Podman's run directory " + targetRunDirAsString));
+        verify(log, times(1)).info("Setting Podman's run directory " + targetRunDirAsString);
     }
 
     @Test
@@ -406,27 +406,27 @@ public class BuildMojoTest extends AbstractMojoTest {
         buildMojo.execute();
 
         // Verify logging
-        verify(log, times(1)).info(Mockito.eq("Detected multistage Containerfile..."));
+        verify(log, times(1)).info("Detected multistage Containerfile...");
 
         // At random verify some lines
-        verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 1: FROM nexus.example:15000/adoptopenjdk/openjdk11:11.0.3 AS base', matches: true"));
-        verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false"));
+        verify(log, times(1)).debug("Processing line: 'STEP 1: FROM nexus.example:15000/adoptopenjdk/openjdk11:11.0.3 AS base', matches: true");
+        verify(log, times(1)).debug("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false");
 
         // Verify stage detection
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: base"));
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase"));
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase2"));
+        verify(log, times(1)).debug("Found stage in Containerfile: base");
+        verify(log, times(1)).debug("Found stage in Containerfile: phase");
+        verify(log, times(1)).debug("Found stage in Containerfile: phase2");
 
         // Verify hashes for stages
-        verify(log, times(1)).info(Mockito.eq("Final image for stage base is: 7e72c870614"));
-        verify(log, times(1)).info(Mockito.eq("Final image for stage phase is: 7f55eab001a"));
-        verify(log, times(1)).info(Mockito.eq("Final image for stage phase2 is: d2efc6645cb"));
+        verify(log, times(1)).info("Final image for stage base is: 7e72c870614");
+        verify(log, times(1)).info("Final image for stage phase is: 7f55eab001a");
+        verify(log, times(1)).info("Final image for stage phase2 is: d2efc6645cb");
 
         // Verify tagging image
-        verify(log, times(1)).info(Mockito.eq("Tagging container image d2efc6645cbb6ea012f8adcaaab6b03ef847dd3d2b4fa418ca4cde57eff28a7f as registry.example.com/sample:1.0.0"));
-        verify(podmanExecutorService, times(1)).tag(eq("d2efc6645cbb6ea012f8adcaaab6b03ef847dd3d2b4fa418ca4cde57eff28a7f"), eq("registry.example.com/sample:1.0.0"));
+        verify(log, times(1)).info("Tagging container image d2efc6645cbb6ea012f8adcaaab6b03ef847dd3d2b4fa418ca4cde57eff28a7f as registry.example.com/sample:1.0.0");
+        verify(podmanExecutorService, times(1)).tag("d2efc6645cbb6ea012f8adcaaab6b03ef847dd3d2b4fa418ca4cde57eff28a7f", "registry.example.com/sample:1.0.0");
 
-        verify(log, times(1)).info(Mockito.eq("Built container image."));
+        verify(log, times(1)).info("Built container image.");
     }
 
     @Test
@@ -462,31 +462,31 @@ public class BuildMojoTest extends AbstractMojoTest {
         buildMojo.execute();
 
         // Verify logging
-        verify(log, times(1)).info(Mockito.eq("Detected multistage Containerfile..."));
+        verify(log, times(1)).info("Detected multistage Containerfile...");
 
         // At random verify some lines
-        verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 1: FROM nexus.example:15000/adoptopenjdk/openjdk11:11.0.3 AS base', matches: true"));
-        verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false"));
+        verify(log, times(1)).debug("Processing line: 'STEP 1: FROM nexus.example:15000/adoptopenjdk/openjdk11:11.0.3 AS base', matches: true");
+        verify(log, times(1)).debug("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false");
 
         // Verify stage detection
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: base"));
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase"));
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase2"));
+        verify(log, times(1)).debug("Found stage in Containerfile: base");
+        verify(log, times(1)).debug("Found stage in Containerfile: phase");
+        verify(log, times(1)).debug("Found stage in Containerfile: phase2");
 
         // Verify hashes for stages
-        verify(log, times(1)).info(Mockito.eq("Final image for stage base is: 7e72c870614"));
-        verify(log, times(1)).info(Mockito.eq("Final image for stage phase is: 7f55eab001a"));
-        verify(log, times(1)).info(Mockito.eq("Final image for stage phase2 is: d2efc6645cb"));
+        verify(log, times(1)).info("Final image for stage base is: 7e72c870614");
+        verify(log, times(1)).info("Final image for stage phase is: 7f55eab001a");
+        verify(log, times(1)).info("Final image for stage phase2 is: d2efc6645cb");
 
         // Verify tagging image
-        verify(log, times(1)).info(Mockito.eq("Tagging container image 7f55eab001a from stage phase as registry.example.com/image-name-number-1:0.2.1"));
-        verify(log, times(1)).info(Mockito.eq("Tagging container image d2efc6645cb from stage phase2 as registry.example.com/image-name-number-2:0.2.1"));
-        verify(log, times(0)).info(Mockito.eq("Tagging container image d2efc6645cb as registry.example.com/sample:1.0.0"));
+        verify(log, times(1)).info("Tagging container image 7f55eab001a from stage phase as registry.example.com/image-name-number-1:0.2.1");
+        verify(log, times(1)).info("Tagging container image d2efc6645cb from stage phase2 as registry.example.com/image-name-number-2:0.2.1");
+        verify(log, times(0)).info("Tagging container image d2efc6645cb as registry.example.com/sample:1.0.0");
 
-        verify(podmanExecutorService, times(1)).tag(eq("7f55eab001a"), eq("registry.example.com/image-name-number-1:0.2.1"));
-        verify(podmanExecutorService, times(1)).tag(eq("d2efc6645cb"), eq("registry.example.com/image-name-number-2:0.2.1"));
+        verify(podmanExecutorService, times(1)).tag("7f55eab001a", "registry.example.com/image-name-number-1:0.2.1");
+        verify(podmanExecutorService, times(1)).tag("d2efc6645cb", "registry.example.com/image-name-number-2:0.2.1");
 
-        verify(log, times(1)).info(Mockito.eq("Built container image."));
+        verify(log, times(1)).info("Built container image.");
     }
 
     @Test
@@ -522,30 +522,30 @@ public class BuildMojoTest extends AbstractMojoTest {
         buildMojo.execute();
 
         // Verify logging
-        verify(log, times(1)).info(Mockito.eq("Detected multistage Containerfile..."));
+        verify(log, times(1)).info("Detected multistage Containerfile...");
 
         // At random verify some lines
-        verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 1: FROM nexus.example:15000/adoptopenjdk/openjdk11:11.0.3 AS base', matches: true"));
-        verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false"));
+        verify(log, times(1)).debug("Processing line: 'STEP 1: FROM nexus.example:15000/adoptopenjdk/openjdk11:11.0.3 AS base', matches: true");
+        verify(log, times(1)).debug("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false");
 
         // Verify stage detection
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: base"));
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase"));
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase2"));
+        verify(log, times(1)).debug("Found stage in Containerfile: base");
+        verify(log, times(1)).debug("Found stage in Containerfile: phase");
+        verify(log, times(1)).debug("Found stage in Containerfile: phase2");
 
         // Verify hashes for stages
-        verify(log, times(1)).info(Mockito.eq("Final image for stage base is: 7e72c870614"));
-        verify(log, times(1)).info(Mockito.eq("Final image for stage phase is: 7f55eab001a"));
-        verify(log, times(1)).info(Mockito.eq("Final image for stage phase2 is: d2efc6645cb"));
+        verify(log, times(1)).info("Final image for stage base is: 7e72c870614");
+        verify(log, times(1)).info("Final image for stage phase is: 7f55eab001a");
+        verify(log, times(1)).info("Final image for stage phase2 is: d2efc6645cb");
 
         // Verify tagging image
-        verify(log, times(1)).info(Mockito.eq("Tagging container image 7f55eab001a from stage phase as registry.example.com/image-name-number-1:0.2.1"));
-        verify(log, times(1)).info(Mockito.eq("Tagging container image d2efc6645cb from stage phase2 as registry.example.com/image-name-number-2:0.2.1"));
+        verify(log, times(1)).info("Tagging container image 7f55eab001a from stage phase as registry.example.com/image-name-number-1:0.2.1");
+        verify(log, times(1)).info("Tagging container image d2efc6645cb from stage phase2 as registry.example.com/image-name-number-2:0.2.1");
 
-        verify(podmanExecutorService, times(1)).tag(eq("7f55eab001a"), eq("registry.example.com/image-name-number-1:0.2.1"));
-        verify(podmanExecutorService, times(1)).tag(eq("d2efc6645cb"), eq("registry.example.com/image-name-number-2:0.2.1"));
+        verify(podmanExecutorService, times(1)).tag("7f55eab001a", "registry.example.com/image-name-number-1:0.2.1");
+        verify(podmanExecutorService, times(1)).tag("d2efc6645cb", "registry.example.com/image-name-number-2:0.2.1");
 
-        verify(log, times(1)).info(Mockito.eq("Built container image."));
+        verify(log, times(1)).info("Built container image.");
     }
 
     @Test
@@ -581,30 +581,30 @@ public class BuildMojoTest extends AbstractMojoTest {
         buildMojo.execute();
 
         // Verify logging
-        verify(log, times(1)).info(Mockito.eq("Detected multistage Containerfile..."));
+        verify(log, times(1)).info("Detected multistage Containerfile...");
 
         // At random verify some lines
-        verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 1: FROM nexus.example:15000/adoptopenjdk/openjdk11:11.0.3 AS base', matches: true"));
-        verify(log, times(1)).debug(Mockito.eq("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false"));
+        verify(log, times(1)).debug("Processing line: 'STEP 1: FROM nexus.example:15000/adoptopenjdk/openjdk11:11.0.3 AS base', matches: true");
+        verify(log, times(1)).debug("Processing line: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null', matches: false");
 
         // Verify stage detection
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: base"));
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase"));
-        verify(log, times(1)).debug(Mockito.eq("Found stage in Containerfile: phase2"));
+        verify(log, times(1)).debug("Found stage in Containerfile: base");
+        verify(log, times(1)).debug("Found stage in Containerfile: phase");
+        verify(log, times(1)).debug("Found stage in Containerfile: phase2");
 
         // Verify hashes for stages
-        verify(log, times(1)).info(Mockito.eq("Final image for stage base is: 823ed30df4abf7574498d5f766b0ebf70793d73a99fc4220dda200c5131b60ce"));
-        verify(log, times(1)).info(Mockito.eq("Final image for stage phase is: b51d6faa80bc4cc9ea93ec3b3b3bdff9629500330df37295c72d388d17b9c303"));
-        verify(log, times(1)).info(Mockito.eq("Final image for stage phase2 is: ba6cb6863b48c3487810458db4b88b238f086cef65078839d9efe30f1069bed7"));
+        verify(log, times(1)).info("Final image for stage base is: 823ed30df4abf7574498d5f766b0ebf70793d73a99fc4220dda200c5131b60ce");
+        verify(log, times(1)).info("Final image for stage phase is: b51d6faa80bc4cc9ea93ec3b3b3bdff9629500330df37295c72d388d17b9c303");
+        verify(log, times(1)).info("Final image for stage phase2 is: ba6cb6863b48c3487810458db4b88b238f086cef65078839d9efe30f1069bed7");
 
         // Verify tagging image
-        verify(log, times(1)).info(Mockito.eq("Tagging container image b51d6faa80bc4cc9ea93ec3b3b3bdff9629500330df37295c72d388d17b9c303 from stage phase as registry.example.com/image-name-number-1:0.2.1"));
-        verify(log, times(1)).info(Mockito.eq("Tagging container image ba6cb6863b48c3487810458db4b88b238f086cef65078839d9efe30f1069bed7 from stage phase2 as registry.example.com/image-name-number-2:0.2.1"));
+        verify(log, times(1)).info("Tagging container image b51d6faa80bc4cc9ea93ec3b3b3bdff9629500330df37295c72d388d17b9c303 from stage phase as registry.example.com/image-name-number-1:0.2.1");
+        verify(log, times(1)).info("Tagging container image ba6cb6863b48c3487810458db4b88b238f086cef65078839d9efe30f1069bed7 from stage phase2 as registry.example.com/image-name-number-2:0.2.1");
 
-        verify(podmanExecutorService, times(1)).tag(eq("b51d6faa80bc4cc9ea93ec3b3b3bdff9629500330df37295c72d388d17b9c303"), eq("registry.example.com/image-name-number-1:0.2.1"));
-        verify(podmanExecutorService, times(1)).tag(eq("ba6cb6863b48c3487810458db4b88b238f086cef65078839d9efe30f1069bed7"), eq("registry.example.com/image-name-number-2:0.2.1"));
+        verify(podmanExecutorService, times(1)).tag("b51d6faa80bc4cc9ea93ec3b3b3bdff9629500330df37295c72d388d17b9c303", "registry.example.com/image-name-number-1:0.2.1");
+        verify(podmanExecutorService, times(1)).tag("ba6cb6863b48c3487810458db4b88b238f086cef65078839d9efe30f1069bed7", "registry.example.com/image-name-number-2:0.2.1");
 
-        verify(log, times(1)).info(Mockito.eq("Built container image."));
+        verify(log, times(1)).info("Built container image.");
     }
 
     private void configureMojo(PodmanConfiguration podman, ImageConfiguration image, boolean skipAuth, boolean skipAll, boolean skipBuild, boolean skipTag, boolean failOnMissingContainerFile) {

--- a/src/test/resources/multistagecontainerfile/samplebuildoutput2.txt
+++ b/src/test/resources/multistagecontainerfile/samplebuildoutput2.txt
@@ -1,0 +1,36 @@
+Building container image...
+STEP 1: FROM nexus.example:15000/adoptopenjdk/openjdk11:11.0.3 AS base
+Getting image source signatures
+Copying blob sha256:df15d82c4ffe976522b836c1f0c300e289f797cb2e302df1b7d0b917af7d3795
+Copying blob sha256:c29f4698c17768b4bf36dde25d584231424db9f4b9c9e67cce8980cfc50efbc1
+Copying blob sha256:b08df05e829707fdd711d6669671a0dd0431a20ca7ae89d7cd415e0025ba3a84
+Copying blob sha256:ad26192fb1166465550d702a8418c67ecda7b089149870f48673d8f0fb5ab8c1
+Copying blob sha256:95c2c089cb32f9959093f091b223b04c3a8e0e0aa8b703c0052ebfe9be5f0b3c
+Copying blob sha256:67300986eedeec2c7442a3b30e65142200b72dc72dc6da2e945a0f06d5e9183b
+Copying config sha256:c83be72afce332f5c3c3ae4992f3340479fee3115d7f449afebf39d0b6eb16b6
+Writing manifest to image destination
+Storing signatures
+STEP 2: LABEL Build-User=example Git-Repository-Url=null
+--> ab579b718da
+STEP 3: ENV RUN_CMD="exec java -jar a-sample-jar-file.jar"
+--> d8874e40423
+STEP 4: WORKDIR /application
+--> 932d8db203e
+STEP 5: ENTRYPOINT /application
+--> 7e72c870614
+STEP 6: FROM 7e72c870614c842cefe268dec15cd84d8abd64be16a0c4f76d4883846b1e6104 AS phase
+STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null
+--> f6d4d237662
+STEP 8: COPY target/a-sample-jar-file.jar ./
+--> 1149d5e6695
+STEP 9: ENTRYPOINT ${RUN_CMD}
+--> 7f55eab001a
+STEP 10: FROM 7e72c870614c842cefe268dec15cd84d8abd64be16a0c4f76d4883846b1e6104 AS phase2
+STEP 11: LABEL Build-User=another-user Git-Repository-Url=null
+--> 521e4fbdc40
+STEP 12: COPY target/some-other-jar-file.jar ./
+--> 15db404a6fb
+STEP 13: ENTRYPOINT ${RUN_CMD}
+STEP 14: COMMIT
+--> d2efc6645cb
+7f55eab001adf2dfeas8adc03ef847dd3d2b4fa42b4fa418ca4cdeb6eaef8f3b

--- a/src/test/resources/multistagecontainerfile/samplebuildoutput_podman1x.txt
+++ b/src/test/resources/multistagecontainerfile/samplebuildoutput_podman1x.txt
@@ -1,0 +1,36 @@
+Building container image...
+STEP 1: FROM nexus.example:15000/adoptopenjdk/openjdk11:11.0.3 AS base
+Getting image source signatures
+Copying blob sha256:df15d82c4ffe976522b836c1f0c300e289f797cb2e302df1b7d0b917af7d3795
+Copying blob sha256:c29f4698c17768b4bf36dde25d584231424db9f4b9c9e67cce8980cfc50efbc1
+Copying blob sha256:b08df05e829707fdd711d6669671a0dd0431a20ca7ae89d7cd415e0025ba3a84
+Copying blob sha256:ad26192fb1166465550d702a8418c67ecda7b089149870f48673d8f0fb5ab8c1
+Copying blob sha256:95c2c089cb32f9959093f091b223b04c3a8e0e0aa8b703c0052ebfe9be5f0b3c
+Copying blob sha256:67300986eedeec2c7442a3b30e65142200b72dc72dc6da2e945a0f06d5e9183b
+Copying config sha256:c83be72afce332f5c3c3ae4992f3340479fee3115d7f449afebf39d0b6eb16b6
+Writing manifest to image destination
+Storing signatures
+STEP 2: LABEL Build-User=example Git-Repository-Url=null
+fdb500249b3b8db3bdd0857d4bdfdbdbde12901987f792d84fa54c1bf7d9dec7
+STEP 3: ENV RUN_CMD="exec java -jar a-sample-jar-file.jar"
+7f1f1bd5ceb0013496d519bb799a5589f16d41a1554a1a55ce1bd367dc7da1b3
+STEP 4: WORKDIR /application
+ffe9fdbba1c18cfb6563652d9f60425c0f465526855fa97582e20cefbe2d112f
+STEP 5: ENTRYPOINT /application
+823ed30df4abf7574498d5f766b0ebf70793d73a99fc4220dda200c5131b60ce
+STEP 6: FROM 823ed30df4abf7574498d5f766b0ebf70793d73a99fc4220dda200c5131b60ce AS phase
+STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null
+103013b8de849337063c6a3814c85774576303b58c7b7f31aefe8eff63da6b75
+STEP 8: COPY target/a-sample-jar-file.jar ./
+493cf9a1f9e820d6163591acc1b0f5b35136b37302647850e891448d798254c8
+STEP 9: ENTRYPOINT ${RUN_CMD}
+b51d6faa80bc4cc9ea93ec3b3b3bdff9629500330df37295c72d388d17b9c303
+STEP 10: FROM 823ed30df4abf7574498d5f766b0ebf70793d73a99fc4220dda200c5131b60ce AS phase2
+STEP 11: LABEL Build-User=another-user Git-Repository-Url=null
+afed3f95872aee093de6e1c598df97c8a37c0d8bba5db5f4db567ffa1219a1e3
+STEP 12: COPY target/some-other-jar-file.jar ./
+257504d973a1ae6293d5c40ca4c7f812c6288282e30c67dd38a2c1a03ea1432c
+STEP 13: ENTRYPOINT ${RUN_CMD}
+STEP 14: COMMIT
+ba6cb6863b48c3487810458db4b88b238f086cef65078839d9efe30f1069bed7
+ba6cb6863b48c3487810458db4b88b238f086cef65078839d9efe30f1069bed7


### PR DESCRIPTION
This fixes issue #28. This issue changes the algorithm that is used when building a container image using a multistage Containerfile. The algorithm now uses a lookahead to determine the image hash of a stage rather than a lookback which should be more stable, especially with Podman 2.x.