### PR TITLE
Introduce a pull-always option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Changelog
 ### 1.5.0 (09-02-2020)
 #### Bugs
-* ([#28](https://github.com/lexemmens/podman-maven-plugin/issues/28)) - Changed algorithm for image hash detection when using multistage containerfiles to use lookahead instead of look back. 
+* ([#28](https://github.com/lexemmens/podman-maven-plugin/issues/28)) - Changed algorithm for image hash detection when using multistage containerfiles to use lookahead instead of look back.
+
+#### Improvements
+* ([#30](https://github.com/lexemmens/podman-maven-plugin/issues/30)) - Introduced `pullAlways` option in build configuration whether an image should always be pulled. [More information](http://docs.podman.io/en/latest/markdown/podman-build.1.html#pull-always).
 
 ### 1.4.0 (25-11-2020)
 #### Improvements

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The example in XML below lists all the other configuration options that are poss
                     <containerFile>Containerfile</containerFile>
                     <containerFileDir>path/to/a/directory</containerFileDir>
                     <pull>true</pull>
+                    <pullAlways>true</pullAlways>
 
                     <tagWithMavenProjectVersion>false</tagWithMavenProjectVersion>
                     <createLatestTag>false</createLatestTag>
@@ -191,8 +192,9 @@ The tables below explains the configuration options for container images that we
 | name                     | String  | Y        | -                  | The name of the container image without the registry or tag. May contain a repository. Example: `some/repo/image`. [Docker naming conventions](https://docs.docker.com/engine/reference/commandline/tag/) apply. |
 | noCache                  | Boolean | N        | false              | Do not use cache when building the image |
 | pull                     | Boolean | N        | true               | Controls whether the image should be pulled if non-existant in local storage |
-| containerFile               | String  | N        | Containerfile         | Allows using a Containerfile that is named differently |
-| containerFileDir            | String  | N        | Current Module Dir | Specifies in which directory to find the Containerfile |
+| pullAlways               | Boolean | N        | false              | Controls whether the base image should always be pulled from the registry |
+| containerFile            | String  | N        | Containerfile      | Allows using a Containerfile that is named differently |
+| containerFileDir         | String  | N        | Current Module Dir | Specifies in which directory to find the Containerfile |
 | tagAsMavenProjectVersion | Boolean | N        | false              | When set to true, the container image will automatically be tagged with the version of the Maven project. Note that a container can receive one or more tags whilst maintaining the same name. |
 | createLatestTag          | Boolean | N        | false              | When set to true, the container image will automatically be tagged 'latest'. Note that a container can receive one or more tags whilst maintaining the same name. |
 | labels                   | Map     | N        | -                  | When set, the Containerfile will be decorated with the specified labels. Useful when adding metadata to your images |

--- a/src/main/java/nl/lexemmens/podman/image/BuildImageConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/image/BuildImageConfiguration.java
@@ -45,6 +45,17 @@ public class BuildImageConfiguration {
     @Parameter
     protected Boolean pull;
 
+    /**
+     * Configures whether from-images should always be pulled from the first registry it is found in.
+     *
+     * From Podman docs:
+     * Pull the image from the first registry it is found in as listed in registries.conf.
+     * Raise an error if not found in the registries, even if the image is present locally.
+     *
+     * @see <a href="https://docs.podman.io/en/latest/markdown/podman-build.1.html#pull-always">--pull-always on docs.podman.io</a>
+     */
+    @Parameter
+    protected Boolean pullAlways;
 
     /**
      * Array consisting of one or more tags to attach to a container image.
@@ -140,6 +151,15 @@ public class BuildImageConfiguration {
      */
     public boolean isPull() {
         return pull;
+    }
+
+    /**
+     * Returns if the --pull-always property should be used
+     *
+     * @return When set to true, podman will build with --pull-always
+     */
+    public boolean isPullAlways() {
+        return pullAlways;
     }
 
     /**
@@ -286,6 +306,10 @@ public class BuildImageConfiguration {
 
         if (pull == null) {
             pull = true;
+        }
+
+        if (pullAlways == null) {
+            pullAlways = false;
         }
 
         this.mavenProjectVersion = project.getVersion();

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -29,6 +29,7 @@ public class PodmanExecutorService {
     private static final String CONTAINERFILE_CMD = "--file=";
     private static final String NO_CACHE_CMD = "--no-cache=";
     private static final String PULL_CMD = "--pull=";
+    private static final String PULL_ALWAYS_CMD = "--pull-always=";
     private static final String ROOT_CMD = "--root=";
     private static final String RUNROOT_CMD = "--runroot=";
 
@@ -77,6 +78,7 @@ public class PodmanExecutorService {
         subCommand.add(CONTAINERFILE_CMD + image.getBuild().getTargetContainerFile());
         subCommand.add(NO_CACHE_CMD + image.getBuild().isNoCache());
         subCommand.add(PULL_CMD + image.getBuild().isPull());
+        subCommand.add(PULL_ALWAYS_CMD + image.getBuild().isPullAlways());
         subCommand.add(".");
 
         return runCommand(podmanRunDirectory, false, PodmanCommand.BUILD, subCommand);

--- a/src/test/java/nl/lexemmens/podman/image/TestImageConfigurationBuilder.java
+++ b/src/test/java/nl/lexemmens/podman/image/TestImageConfigurationBuilder.java
@@ -97,6 +97,11 @@ public class TestImageConfigurationBuilder {
         return this;
     }
 
+    public TestImageConfigurationBuilder setPullAlways(boolean pullAlways) {
+        image.build.pullAlways = pullAlways;
+        return this;
+    }
+
     public ImageConfiguration build() {
         return image;
     }

--- a/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
+++ b/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
@@ -202,8 +202,8 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true .",
-                delegate.getCommandAsString());
+        Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true " +
+                        "--pull-always=false .", delegate.getCommandAsString());
     }
 
     @Test
@@ -224,8 +224,31 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman build --tls-verify=true --format=docker --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true .",
-                delegate.getCommandAsString());
+        Assertions.assertEquals("podman build --tls-verify=true --format=docker --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false " +
+                        "--pull=true --pull-always=false .", delegate.getCommandAsString());
+    }
+
+    @Test
+    public void testBuildPullAlways() throws MojoExecutionException {
+        when(mavenProject.getBuild()).thenReturn(build);
+        when(build.getDirectory()).thenReturn("target");
+
+        PodmanConfiguration podmanConfig = new TestPodmanConfigurationBuilder().setTlsVerify(TRUE).initAndValidate(mavenProject, log).build();
+        ImageConfiguration image = new TestImageConfigurationBuilder("test_image")
+                .setFormat(OCI)
+                .setPullAlways(true)
+                .setContainerfileDir("src/test/resources")
+                .initAndValidate(mavenProject, log, true)
+                .build();
+
+        String sampleImageHash = "this_would_normally_be_an_image_hash";
+        InterceptorCommandExecutorDelegate delegate = new InterceptorCommandExecutorDelegate(List.of(sampleImageHash));
+        podmanExecutorService = new PodmanExecutorService(log, podmanConfig, delegate);
+
+        podmanExecutorService.build(image);
+
+        Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false " +
+                "--pull=true --pull-always=true .", delegate.getCommandAsString());
     }
 
     @Test
@@ -251,8 +274,8 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman --root=/some/custom/root/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true .",
-                delegate.getCommandAsString());
+        Assertions.assertEquals("podman --root=/some/custom/root/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() +
+                        " --no-cache=false --pull=true --pull-always=false .", delegate.getCommandAsString());
     }
 
     @Test
@@ -278,8 +301,8 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true .",
-                delegate.getCommandAsString());
+        Assertions.assertEquals("podman --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() +
+                        " --no-cache=false --pull=true --pull-always=false .", delegate.getCommandAsString());
     }
 
     @Test
@@ -306,7 +329,8 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman --root=/some/custom/root/dir --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true .",
+        Assertions.assertEquals("podman --root=/some/custom/root/dir --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci " +
+                        "--file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true --pull-always=false .",
                 delegate.getCommandAsString());
     }
 


### PR DESCRIPTION
Introduce the equivalent of Podman's `--pull-always` option to force an image to be always pulled from the registry.

Fixes #30 