### PR TITLE
Fixed #42 by ensuring pull and pullAlways aren't enabled simultaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Changelog
 ### UNRELEASED CHANGES
 #### Bugs
+* ([#42](https://github.com/lexemmens/podman-maven-plugin/issues/42)) - Podman `pull` and `pullAlways` options cannot be enabled simultaneously.
+
+### 1.6.0 (25-03-2021)
+#### Bugs
 * ([#32](https://github.com/lexemmens/podman-maven-plugin/issues/32) - When tagging an image, the plugin might skip one or more steps due to unexpected multiline output for a build step)
 
 #### Improvements

--- a/docs/modules/ROOT/pages/goals/build.adoc
+++ b/docs/modules/ROOT/pages/goals/build.adoc
@@ -25,7 +25,7 @@ This section covers all the possible options for the `<build>` tag.
 |pull
 |When the option is specified or set to “true”, pull the image. Raise an error if the image could not be pulled, even if the image is present locally.
 
-If the option is disabled (with –pull=false) or not specified, pull the image from the registry only if the image is not present locally. Raise an error if the image is not found in the registries and is not present locally.
+If the option is disabled (with `<pull>false</pull>`) or not specified, pull the image from the registry only if the image is not present locally. Raise an error if the image is not found in the registries and is not present locally.
 
 When this option is specified _and_ `pullAlways` is also specified, builds will fail as Podman does not support both options to be enabled at the same time.
 

--- a/docs/modules/ROOT/pages/goals/build.adoc
+++ b/docs/modules/ROOT/pages/goals/build.adoc
@@ -27,14 +27,18 @@ This section covers all the possible options for the `<build>` tag.
 
 If the option is disabled (with –pull=false) or not specified, pull the image from the registry only if the image is not present locally. Raise an error if the image is not found in the registries and is not present locally.
 
-**Default value is**: `true` (note: deviates from Podman defaults)
+When this option is specified _and_ `pullAlways` is also specified, builds will fail as Podman does not support both options to be enabled at the same time.
+
+**Default value is**: `null` (not specified).
 
 **See**: https://docs.podman.io/en/latest/markdown/podman-build.1.html
 
 |pullAlways
 |Pull the image from the first registry it is found in as listed in registries.conf. Raise an error if not found in the registries, even if the image is present locally.
 
-**Default value is**: `false`
+When this option is specified _and_ `pullAlways` is also specified, builds will fail as Podman does not support both options to be enabled at the same time.
+
+**Default value is**: `null` (not specified).
 
 **See**: https://docs.podman.io/en/latest/markdown/podman-build.1.html
 

--- a/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
@@ -140,8 +140,8 @@ public abstract class AbstractImageBuildConfiguration {
      *
      * @return When set to true, podman will build with --pull
      */
-    public boolean isPull() {
-        return pull;
+    public Optional<Boolean> getPull() {
+        return Optional.ofNullable(pull);
     }
 
     /**
@@ -149,21 +149,13 @@ public abstract class AbstractImageBuildConfiguration {
      *
      * @return When set to true, podman will build with --pull-always
      */
-    public boolean isPullAlways() {
-        return pullAlways;
+    public Optional<Boolean> getPullAlways() {
+        return Optional.ofNullable(pullAlways);
     }
 
-    public void validate(MavenProject project) {
+    public void validate(MavenProject project) throws MojoExecutionException {
         if (containerFile == null) {
             containerFile = DEFAULT_CONTAINERFILE;
-        }
-
-        if (pull == null) {
-            pull = true;
-        }
-
-        if (pullAlways == null) {
-            pullAlways = false;
         }
 
         if (labels == null) {

--- a/src/main/java/nl/lexemmens/podman/config/image/batch/BatchImageConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/batch/BatchImageConfiguration.java
@@ -75,10 +75,18 @@ public class BatchImageConfiguration extends AbstractImageConfiguration<BatchIma
             buildConfiguration.setFormat(getBuild().getFormat());
             buildConfiguration.setCreateLatestTag(getBuild().isCreateLatestTag());
             buildConfiguration.setLabels(getBuild().getLabels());
-            buildConfiguration.setPull(getBuild().isPull());
+
+            if(getBuild().getPull().isPresent()) {
+                buildConfiguration.setPull(getBuild().getPull().get());
+            }
+
             buildConfiguration.setNoCache(getBuild().isNoCache());
             buildConfiguration.setTags(getBuild().getTags());
-            buildConfiguration.setPullAlways(getBuild().isPullAlways());
+
+            if(getBuild().getPullAlways().isPresent()) {
+                buildConfiguration.setPullAlways(getBuild().getPullAlways().get());
+            }
+
             buildConfiguration.setTagWithMavenProjectVersion(getBuild().isTagWithMavenProjectVersion());
 
             imageConfiguration.setBuild(buildConfiguration);

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -79,8 +79,15 @@ public class PodmanExecutorService {
         subCommand.add(BUILD_FORMAT_CMD + image.getBuild().getFormat().getValue());
         subCommand.add(CONTAINERFILE_CMD + image.getBuild().getTargetContainerFile());
         subCommand.add(NO_CACHE_CMD + image.getBuild().isNoCache());
-        subCommand.add(PULL_CMD + image.getBuild().isPull());
-        subCommand.add(PULL_ALWAYS_CMD + image.getBuild().isPullAlways());
+
+        if(image.getBuild().getPull().isPresent()) {
+            subCommand.add(PULL_CMD + image.getBuild().getPull().get());
+        }
+
+        if(image.getBuild().getPullAlways().isPresent()) {
+            subCommand.add(PULL_ALWAYS_CMD + image.getBuild().getPullAlways().get());
+        }
+
         subCommand.add(".");
 
         return runCommand(podmanRunDirectory, false, PodmanCommand.BUILD, subCommand);

--- a/src/test/java/nl/lexemmens/podman/BatchBuildMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/BatchBuildMojoTest.java
@@ -27,9 +27,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
+import static net.bytebuddy.matcher.ElementMatchers.anyOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -242,8 +247,16 @@ public class BatchBuildMojoTest extends AbstractMojoTest {
 
         assertEquals(2, buildMojo.resolvedImages.size());
 
+
+        // The order in which the directories are resolved is not defined.
+        // See: https://stackoverflow.com/questions/10396649/order-of-traversal-in-files-walkfiletree
+        // As such, we cannot make any assumptions on the expected order with respect to naming.
+        List<String> expectedImageNames = new ArrayList<>();
+        expectedImageNames.add("sample-image-batch");
+        expectedImageNames.add("sample-image-subdir");
+
         SingleImageConfiguration image1 = buildMojo.resolvedImages.get(0);
-        assertEquals("sample-image-batch", image1.getImageName());
+        assertTrue(expectedImageNames.contains(image1.getImageName()));
         assertEquals(1, image1.getStages().length);
         assertFalse(image1.useCustomImageNameForMultiStageContainerfile());
         assertNotNull(image1.getBuild());
@@ -251,7 +264,7 @@ public class BatchBuildMojoTest extends AbstractMojoTest {
         assertEquals("1.0.0", image1.getBuild().getAllTags().get(0));
 
         SingleImageConfiguration image2 = buildMojo.resolvedImages.get(1);
-        assertEquals("sample-image-subdir", image2.getImageName());
+        assertTrue(expectedImageNames.contains(image1.getImageName()));
         assertEquals(1, image2.getStages().length);
         assertFalse(image2.useCustomImageNameForMultiStageContainerfile());
         assertNotNull(image2.getBuild());

--- a/src/test/java/nl/lexemmens/podman/BatchBuildMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/BatchBuildMojoTest.java
@@ -206,8 +206,10 @@ public class BatchBuildMojoTest extends AbstractMojoTest {
         assertNotNull(image1.getBuild());
         assertEquals(1, image1.getBuild().getAllTags().size());
         assertEquals("latest", image1.getBuild().getAllTags().get(0));
-        assertTrue(image1.getBuild().isPull());
-        assertTrue(image1.getBuild().isPullAlways());
+        assertTrue(image1.getBuild().getPull().isPresent());
+        assertTrue(image1.getBuild().getPull().get());
+        assertTrue(image1.getBuild().getPullAlways().isPresent());
+        assertTrue(image1.getBuild().getPullAlways().get());
         assertEquals(ContainerFormat.DOCKER, image1.getBuild().getFormat());
     }
 

--- a/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
+++ b/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
@@ -203,8 +203,8 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true " +
-                        "--pull-always=false .", delegate.getCommandAsString());
+        Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false .",
+                delegate.getCommandAsString());
     }
 
     @Test
@@ -225,8 +225,8 @@ public class PodmanExecutorServiceTest {
 
         podmanExecutorService.build(image);
 
-        Assertions.assertEquals("podman build --tls-verify=true --format=docker --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false " +
-                        "--pull=true --pull-always=false .", delegate.getCommandAsString());
+        Assertions.assertEquals("podman build --tls-verify=true --format=docker --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false .",
+                delegate.getCommandAsString());
     }
 
     @Test
@@ -249,7 +249,30 @@ public class PodmanExecutorServiceTest {
         podmanExecutorService.build(image);
 
         Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false " +
-                "--pull=true --pull-always=true .", delegate.getCommandAsString());
+                "--pull-always=true .", delegate.getCommandAsString());
+    }
+
+    @Test
+    public void testBuildPull() throws MojoExecutionException {
+        when(mavenProject.getBuild()).thenReturn(build);
+        when(build.getDirectory()).thenReturn("target");
+
+        PodmanConfiguration podmanConfig = new TestPodmanConfigurationBuilder().setTlsVerify(TRUE).initAndValidate(mavenProject, log).build();
+        SingleImageConfiguration image = new TestSingleImageConfigurationBuilder("test_image")
+                .setFormat(OCI)
+                .setPull(true)
+                .setContainerfileDir("src/test/resources")
+                .initAndValidate(mavenProject, log, true)
+                .build();
+
+        String sampleImageHash = "this_would_normally_be_an_image_hash";
+        InterceptorCommandExecutorDelegate delegate = new InterceptorCommandExecutorDelegate(Collections.singletonList(sampleImageHash));
+        podmanExecutorService = new PodmanExecutorService(log, podmanConfig, delegate);
+
+        podmanExecutorService.build(image);
+
+        Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false " +
+                "--pull=true .", delegate.getCommandAsString());
     }
 
     @Test
@@ -276,7 +299,7 @@ public class PodmanExecutorServiceTest {
         podmanExecutorService.build(image);
 
         Assertions.assertEquals("podman --root=/some/custom/root/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() +
-                        " --no-cache=false --pull=true --pull-always=false .", delegate.getCommandAsString());
+                        " --no-cache=false .", delegate.getCommandAsString());
     }
 
     @Test
@@ -303,7 +326,7 @@ public class PodmanExecutorServiceTest {
         podmanExecutorService.build(image);
 
         Assertions.assertEquals("podman --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() +
-                        " --no-cache=false --pull=true --pull-always=false .", delegate.getCommandAsString());
+                        " --no-cache=false .", delegate.getCommandAsString());
     }
 
     @Test
@@ -331,7 +354,7 @@ public class PodmanExecutorServiceTest {
         podmanExecutorService.build(image);
 
         Assertions.assertEquals("podman --root=/some/custom/root/dir --runroot=/some/custom/runroot/dir build --tls-verify=true --format=oci " +
-                        "--file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false --pull=true --pull-always=false .",
+                        "--file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false .",
                 delegate.getCommandAsString());
     }
 


### PR DESCRIPTION
The `podman-maven-plugin` no longer sets both `pull` and `pullAlways` options by default. It is now up to the user to set only one of them. Podman will fail automatically when both options are set, so no reason to do this in the plugin itself.

This fixes #42 