### PR TITLE
Log warning when tagging is skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Bugs
 * ([#42](https://github.com/lexemmens/podman-maven-plugin/issues/42)) - Podman `pull` and `pullAlways` options cannot be enabled simultaneously.
 * ([#44](https://github.com/lexemmens/podman-maven-plugin/issues/44)) - Images are now by default saved to the target directory of the Maven module where Podman is configued.
+* ([#41](https://github.com/lexemmens/podman-maven-plugin/issues/41)) - Implemented a warning marker when there is no image name configured for a particular stage.
 
 #### Improvements
 * ([#44](https://github.com/lexemmens/podman-maven-plugin/issues/44)) - SaveMojo: The location where images are saved on disk can now be configured. Also, the push registry is no longer part of the file name.

--- a/src/main/java/nl/lexemmens/podman/BuildMojo.java
+++ b/src/main/java/nl/lexemmens/podman/BuildMojo.java
@@ -98,26 +98,30 @@ public class BuildMojo extends AbstractPodmanMojo {
         }
 
         if (image.getBuild().isMultistageContainerFile() && image.useCustomImageNameForMultiStageContainerfile()) {
-            for (Map.Entry<String, String> stageImage : image.getImageHashPerStage().entrySet()) {
-                List<String> imageNamesByStage = image.getImageNamesByStage(stageImage.getKey());
-
-                if(imageNamesByStage.isEmpty()) {
-                    getLog().warn("No image name configured for build stage: " + stageImage.getKey() + ". Image " + stageImage.getValue() + " not tagged!");
-                } else {
-                    for (String imageName : imageNamesByStage) {
-                        String fullImageName = getFullImageNameWithPushRegistry(imageName);
-
-                        getLog().info("Tagging container image " + stageImage.getValue() + " from stage " + stageImage.getKey() + " as " + fullImageName);
-
-                        hub.getPodmanExecutorService().tag(stageImage.getValue(), fullImageName);
-                    }
-                }
-            }
+            tagImagesOfMultiStageContainerfile(image, hub);
         } else if (image.getBuild().isMultistageContainerFile()) {
             getLog().warn("Missing container names for multistage Containerfile. Falling back to tagging the final container image.");
             tagFinalImage(image, hub);
         } else {
             tagFinalImage(image, hub);
+        }
+    }
+
+    private void tagImagesOfMultiStageContainerfile(SingleImageConfiguration image, ServiceHub hub) throws MojoExecutionException {
+        for (Map.Entry<String, String> stageImage : image.getImageHashPerStage().entrySet()) {
+            List<String> imageNamesByStage = image.getImageNamesByStage(stageImage.getKey());
+
+            if(imageNamesByStage.isEmpty()) {
+                getLog().warn("No image name configured for build stage: " + stageImage.getKey() + ". Image " + stageImage.getValue() + " not tagged!");
+            } else {
+                for (String imageName : imageNamesByStage) {
+                    String fullImageName = getFullImageNameWithPushRegistry(imageName);
+
+                    getLog().info("Tagging container image " + stageImage.getValue() + " from stage " + stageImage.getKey() + " as " + fullImageName);
+
+                    hub.getPodmanExecutorService().tag(stageImage.getValue(), fullImageName);
+                }
+            }
         }
     }
 

--- a/src/main/java/nl/lexemmens/podman/BuildMojo.java
+++ b/src/main/java/nl/lexemmens/podman/BuildMojo.java
@@ -99,12 +99,18 @@ public class BuildMojo extends AbstractPodmanMojo {
 
         if (image.getBuild().isMultistageContainerFile() && image.useCustomImageNameForMultiStageContainerfile()) {
             for (Map.Entry<String, String> stageImage : image.getImageHashPerStage().entrySet()) {
-                for (String imageName : image.getImageNamesByStage(stageImage.getKey())) {
-                    String fullImageName = getFullImageNameWithPushRegistry(imageName);
+                List<String> imageNamesByStage = image.getImageNamesByStage(stageImage.getKey());
 
-                    getLog().info("Tagging container image " + stageImage.getValue() + " from stage " + stageImage.getKey() + " as " + fullImageName);
+                if(imageNamesByStage.isEmpty()) {
+                    getLog().warn("No image name configured for build stage: " + stageImage.getKey() + ". Image " + stageImage.getValue() + " not tagged!");
+                } else {
+                    for (String imageName : imageNamesByStage) {
+                        String fullImageName = getFullImageNameWithPushRegistry(imageName);
 
-                    hub.getPodmanExecutorService().tag(stageImage.getValue(), fullImageName);
+                        getLog().info("Tagging container image " + stageImage.getValue() + " from stage " + stageImage.getKey() + " as " + fullImageName);
+
+                        hub.getPodmanExecutorService().tag(stageImage.getValue(), fullImageName);
+                    }
                 }
             }
         } else if (image.getBuild().isMultistageContainerFile()) {

--- a/src/main/java/nl/lexemmens/podman/SaveMojo.java
+++ b/src/main/java/nl/lexemmens/podman/SaveMojo.java
@@ -12,7 +12,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * SaveMojo for exporting container images to the file system

--- a/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
@@ -540,6 +540,61 @@ public class BuildMojoTest extends AbstractMojoTest {
     }
 
     @Test
+    public void testMultiStageBuildWithCustomTagPerStageButStageNameIsNotConfigured() throws MojoExecutionException, IOException, URISyntaxException {
+        URI sampleBuildOutputUri = PushMojoTest.class.getResource("/multistagecontainerfile/samplebuildoutput.txt").toURI();
+        Path sampleBuildOutputPath = Paths.get(sampleBuildOutputUri);
+
+        List<String> buildOutputUnderTest = null;
+        try (Stream<String> buildSampleOutput = Files.lines(sampleBuildOutputPath)) {
+            buildOutputUnderTest = buildSampleOutput.collect(Collectors.toList());
+        }
+
+        Assertions.assertNotNull(buildOutputUnderTest);
+
+        PodmanConfiguration podman = new TestPodmanConfigurationBuilder().setTlsVerify(TlsVerify.FALSE).build();
+        SingleImageConfiguration image = new TestSingleImageConfigurationBuilder("sample")
+                .setContainerfileDir("src/test/resources/multistagecontainerfile")
+                .setTags(new String[]{"0.2.1"})
+                .setCreateLatestTag(false)
+                .setUseCustomImageNameForMultiStageContainerfile(true)
+                .addCustomImageNameForBuildStage("non-existent-phase", "image-name-number-1")
+                .build();
+        configureMojo(podman, image, true, false, false, false, true);
+
+        when(mavenProject.getBuild()).thenReturn(build);
+        when(build.getDirectory()).thenReturn("target");
+        when(serviceHubFactory.createServiceHub(isA(Log.class), isA(MavenProject.class), isA(MavenFileFilter.class), isA(PodmanConfiguration.class), isA(Settings.class), isA(SettingsDecrypter.class))).thenReturn(serviceHub);
+        when(serviceHub.getContainerfileDecorator()).thenReturn(containerfileDecorator);
+        when(serviceHub.getPodmanExecutorService()).thenReturn(podmanExecutorService);
+        when(podmanExecutorService.build(isA(SingleImageConfiguration.class))).thenReturn(buildOutputUnderTest);
+
+        buildMojo.execute();
+
+        // Verify logging
+        verify(log, times(1)).info("Detected multistage Containerfile...");
+
+        // At random verify some lines
+        verify(log, times(1)).debug("Processing line: 'STEP 1: FROM nexus.example:15000/adoptopenjdk/openjdk11:11.0.3 AS base'");
+        verify(log, times(1)).debug("Processing candidate: 'STEP 7: LABEL Build-User=sample-user2 Git-Repository-Url=null'");
+
+        // Verify stage detection
+        verify(log, times(1)).debug("Processing stage in Containerfile: base");
+        verify(log, times(1)).debug("Processing stage in Containerfile: phase");
+        verify(log, times(1)).debug("Processing stage in Containerfile: phase2");
+
+        // Verify hashes for stages
+        verify(log, times(1)).info("Final image for stage base is: 7e72c870614");
+        verify(log, times(1)).info("Final image for stage phase is: 7f55eab001a");
+        verify(log, times(1)).info("Final image for stage phase2 is: d2efc6645cb");
+
+        // Verify warning markers
+        verify(log, times(1)).warn("No image name configured for build stage: phase. Image 7f55eab001a not tagged!");
+        verify(log, times(1)).warn("No image name configured for build stage: phase2. Image d2efc6645cb not tagged!");
+
+        verify(log, times(1)).info("Built container image.");
+    }
+
+    @Test
     public void testMultiStageContainerFileWithMultilineOutputStep() throws MojoExecutionException, IOException, URISyntaxException {
         URI sampleBuildOutputUri = PushMojoTest.class.getResource("/multistagecontainerfile/samplebuildoutput_multiline_step.txt").toURI();
         Path sampleBuildOutputPath = Paths.get(sampleBuildOutputUri);


### PR DESCRIPTION
Implemented a warning when tagging is skipped as a result of missing or faulty configuration. The build will not fail, as this could be intentional, but a warning is now logged to make it visible why the plugin is behaving the way it is.

This fixed #41 