### PR TITLE
Fix pattern for detecting multistage Containerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 ### UNRELEASED CHANGES
-* None
+* ([#49](https://github.com/lexemmens/podman-maven-plugin/issues/49)) - Using properties in the FROM now succeeds for multistage builds.
 
 ### 1.7.1 (16-08-2021)
 #### Bugs

--- a/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
@@ -26,10 +26,12 @@ import static nl.lexemmens.podman.enumeration.ContainerFormat.OCI;
 public abstract class AbstractImageBuildConfiguration {
 
     /**
-     * This is the regular expression to be used to determine a multistage Containerfiles. For now we only support
+     * This is the regular expression to be used to determine a multistage Containerfile. For now we only support
      * named stages.
      */
-    protected static final Pattern MULTISTAGE_CONTAINERFILE_REGEX = Pattern.compile("(FROM\\s[a-zA-Z0-9./:_\\-]{0,255}\\s)([ASas]{2}\\s)([a-zA-Z0-9./:_\\-]{1,128})");
+    protected static final Pattern MULTISTAGE_CONTAINERFILE_REGEX = Pattern.compile(
+        "(FROM\\s[a-zA-Z0-9./:_\\-${}]{0,255}\\s)([ASas]{2}\\s)([a-zA-Z0-9./:_\\-]{1,128})"
+    );
 
     /**
      * The default name of the Containerfile to build.


### PR DESCRIPTION
This because the detection is done during validation of the Containerfile (before filtering) which means that Maven properties can still be part of the Containerfile. E.g.

```
FROM ${baseImage.name}:${baseImage.version} AS stageName
```

Is a valid use case and should be handled as such.

This fixes #49 