### PR TITLE
Create parent directories for target container file in case they do not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 ### UNRELEASED CHANGES
 * ([#49](https://github.com/lexemmens/podman-maven-plugin/issues/49)) - Using properties in the FROM now succeeds for multistage builds.
+* ([#51](https://github.com/lexemmens/podman-maven-plugin/issues/51)) - Building projects with packaging=pom now succeed because e.g. the target directory will succesfully be created.
 
 ### 1.7.1 (16-08-2021)
 #### Bugs


### PR DESCRIPTION
When packaging=pom is used it might be that the 'target' directory is not created. The plugin then tries to filter the Containerfile and store it in the target dir. However, that directory does not exist and the copyFile fails with 'Failed to filter Containerfile! <path> (No such file or directory).'

This fixes #51