### PR TITLE
Feature/change login to use password stdin, fixing issue #17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+### 1.9.0 (12-01-2022)
+#### Improvements
+* Added configuration options for `--squash` and `--layers`. Can be configured in the `<build>` section of an image.
+
 ### 1.8.0 (12-10-2021)
 #### Bugs
 * ([#49](https://github.com/lexemmens/podman-maven-plugin/issues/49)) - Using properties in the FROM now succeeds for multistage builds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 ### 1.9.0 (12-01-2022)
 #### Improvements
-* Added configuration options for `--squash` and `--layers`. Can be configured in the `<build>` section of an image.
+* Added configuration options for `--squash`, `--squash-all` and `--layers`. Can be configured in the `<build>` section of an image.
 
 ### 1.8.0 (12-10-2021)
 #### Bugs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
+### 1.10.0 (15-01-2022)
+#### Improvements
+* passwords are now passed through stdin of podman process instead of on then commandline.
+
 ### 1.9.0 (12-01-2022)
 #### Improvements
 * Added configuration options for `--squash`, `--squash-all` and `--layers`. Can be configured in the `<build>` section of an image.

--- a/docs/modules/ROOT/pages/authentication.adoc
+++ b/docs/modules/ROOT/pages/authentication.adoc
@@ -56,7 +56,7 @@ The second method of authentication is by using Docker's configuration file. Thi
 [#mavensettings]
 :navtitle: Maven Settings
 
-When a registry that is being used, is neither fount in the Podman authentication file, nor the Docker configuration file, than this plugin will attempt to authenticate those registries using information available in the Mave Settings file. Therefore, you must configure the registries in your Maven settings file.
+When a registry that is being used, is neither found in the Podman authentication file, nor the Docker configuration file, then this plugin will attempt to authenticate those registries using information available in the Maven Settings file. Therefore, you must configure the registries in your Maven settings file.
 
 WARNING: The id of the server **must** match the registries configured in the plugin (see below). The plugin will fail if credentials are missing for any of the provided registries.
 

--- a/docs/modules/ROOT/pages/goals/build.adoc
+++ b/docs/modules/ROOT/pages/goals/build.adoc
@@ -18,6 +18,16 @@ This section covers all the possible options for the `<build>` tag.
 |===
 |Element |Description
 
+|layers
+|Cache intermediate images during the build process (Default is `true`).
+
+Note: You can also override the default value of layers by setting the BUILDAH_LAYERS environment variable.
+`export BUILDAH_LAYERS=true`
+
+**Default value is**: `null` (not specified).
+
+**See**: https://docs.podman.io/en/latest/markdown/podman-build.1.html
+
 |noCache
 |Do not use existing cached images for the container build. Build from the start with a new set of cached layers.
 
@@ -37,6 +47,20 @@ When this option is specified _and_ `pullAlways` is also specified, builds will 
 |Pull the image from the first registry it is found in as listed in registries.conf. Raise an error if not found in the registries, even if the image is present locally.
 
 When this option is specified _and_ `pullAlways` is also specified, builds will fail as Podman does not support both options to be enabled at the same time.
+
+**Default value is**: `null` (not specified).
+
+**See**: https://docs.podman.io/en/latest/markdown/podman-build.1.html
+
+|squash
+|Squash all of the image’s new layers into a single new layer; any preexisting layers are not squashed.
+
+**Default value is**: `null` (not specified).
+
+**See**: https://docs.podman.io/en/latest/markdown/podman-build.1.html
+
+|squashAll
+|Squash all of the new image’s layers (including those inherited from a base image) into a single new layer.
 
 **Default value is**: `null` (not specified).
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.lexemmens</groupId>
     <artifactId>podman-maven-plugin</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Podman Maven Plugin</name>

--- a/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
@@ -362,6 +362,15 @@ public abstract class AbstractImageBuildConfiguration {
     }
 
     /**
+     * Configures whether to cache intermediate images during the build process.
+     *
+     * @param layers The value to set
+     */
+    public void setLayers(Boolean layers) {
+        this.layers = layers;
+    }
+
+    /**
      * Sets the noCache option. Allows configuring whether caching should be used
      * to cache images
      *
@@ -388,6 +397,24 @@ public abstract class AbstractImageBuildConfiguration {
      */
     public void setPullAlways(Boolean pullAlways) {
         this.pullAlways = pullAlways;
+    }
+
+    /**
+     * Configures whether to squash all newly created layers into one layer.
+     *
+     * @param squash The value to set
+     */
+    public void setSquash(Boolean squash) {
+        this.squash = squash;
+    }
+
+    /**
+     * Configures whether to squash all layers into one layer, this includes the base layer(s).
+     *
+     * @param squashAll The value to set
+     */
+    public void setSquashAll(Boolean squashAll) {
+        this.squashAll = squashAll;
     }
 
     /**

--- a/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
@@ -301,7 +301,7 @@ public abstract class AbstractImageBuildConfiguration {
      * @return true when all of the images's new layers should be squashed into a new layer. False otherwise.
      */
     public Boolean getSquashAll() {
-        return squash;
+        return squashAll;
     }
 
     /**

--- a/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
@@ -184,7 +184,7 @@ public abstract class AbstractImageBuildConfiguration {
         return Optional.ofNullable(pullAlways);
     }
 
-    public void validate(MavenProject project) throws MojoExecutionException {
+    public void validate(MavenProject project) {
         if (containerFile == null) {
             containerFile = DEFAULT_CONTAINERFILE;
         }

--- a/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
@@ -114,6 +114,26 @@ public abstract class AbstractImageBuildConfiguration {
     protected ContainerFormat format;
 
     /**
+     * Squash all of the image’s new layers into a single new layer; any preexisting layers are not squashed.
+     * <p>
+     *
+     * @see "http://docs.podman.io/en/latest/markdown/podman-build.1.html"
+     */
+    @Parameter
+    protected Boolean squash;
+
+    /**
+     * Cache intermediate images during the build process (Default is true).
+     * <p>
+     * Note: You can also override the default value of layers by setting the BUILDAH_LAYERS environment variable.
+     * export BUILDAH_LAYERS=true
+     *
+     * @see "http://docs.podman.io/en/latest/markdown/podman-build.1.html"
+     */
+    @Parameter
+    protected Boolean layers;
+
+    /**
      * Will be set when this class is validated using the #initAndValidate() method
      */
     protected File outputDirectory;
@@ -166,6 +186,14 @@ public abstract class AbstractImageBuildConfiguration {
 
         if (format == null) {
             format = OCI;
+        }
+
+        if (layers == null) {
+            layers = true;
+        }
+
+        if (squash == null) {
+            squash = false;
         }
 
         this.mavenProjectVersion = project.getVersion();
@@ -254,6 +282,25 @@ public abstract class AbstractImageBuildConfiguration {
      */
     public Pattern getMultistageContainerfilePattern() {
         return MULTISTAGE_CONTAINERFILE_REGEX;
+    }
+
+    /**
+     * Returns true when all of the image’s new layers should be squashed into a single new layer; any
+     * preexisting layers are not squashed.
+     *
+     * @return true when all of the images's new layers should be squashed into a new layer. False otherwise.
+     */
+    public boolean isSquash() {
+        return squash;
+    }
+
+    /**
+     * Returns true if intermediate layers should be cached during a Podman build.
+     *
+     * @return true, when intermediate layers should be cached. False otherwise.
+     */
+    public boolean isLayers() {
+        return layers;
     }
 
     /**

--- a/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
@@ -123,6 +123,15 @@ public abstract class AbstractImageBuildConfiguration {
     protected Boolean squash;
 
     /**
+     * Squash all of the new image’s layers (including those inherited from a base image) into a single new layer.
+     * <p>
+     *
+     * @see "http://docs.podman.io/en/latest/markdown/podman-build.1.html"
+     */
+    @Parameter
+    protected Boolean squashAll;
+
+    /**
      * Cache intermediate images during the build process (Default is true).
      * <p>
      * Note: You can also override the default value of layers by setting the BUILDAH_LAYERS environment variable.
@@ -186,14 +195,6 @@ public abstract class AbstractImageBuildConfiguration {
 
         if (format == null) {
             format = OCI;
-        }
-
-        if (layers == null) {
-            layers = true;
-        }
-
-        if (squash == null) {
-            squash = false;
         }
 
         this.mavenProjectVersion = project.getVersion();
@@ -290,7 +291,16 @@ public abstract class AbstractImageBuildConfiguration {
      *
      * @return true when all of the images's new layers should be squashed into a new layer. False otherwise.
      */
-    public boolean isSquash() {
+    public Boolean getSquash() {
+        return squash;
+    }
+
+    /**
+     * Returns true when all of the image’s new layers, including those inherited from a base image, into a single new layer.
+     *
+     * @return true when all of the images's new layers should be squashed into a new layer. False otherwise.
+     */
+    public Boolean getSquashAll() {
         return squash;
     }
 
@@ -299,7 +309,7 @@ public abstract class AbstractImageBuildConfiguration {
      *
      * @return true, when intermediate layers should be cached. False otherwise.
      */
-    public boolean isLayers() {
+    public Boolean getLayers() {
         return layers;
     }
 

--- a/src/main/java/nl/lexemmens/podman/config/podman/PodmanConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/podman/PodmanConfiguration.java
@@ -1,7 +1,6 @@
 package nl.lexemmens.podman.config.podman;
 
 import nl.lexemmens.podman.enumeration.TlsVerify;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -94,11 +93,10 @@ public class PodmanConfiguration {
     /**
      * Validates and initializes this configuration
      *
-     * @param log Access to Maven's log system for informational purposes.
-     * @param project The Maven Project
-     * @throws MojoExecutionException In case validation fails.
+     * @param project The current Maven Project.
+     * @param log     Access to Maven's log system for informational purposes.
      */
-    public void initAndValidate(MavenProject project, Log log) throws MojoExecutionException {
+    public void initAndValidate(MavenProject project, Log log) {
         if (tlsVerify == null) {
             log.debug("Setting TLS Verify to NOT_SPECIFIED");
             tlsVerify = NOT_SPECIFIED;

--- a/src/main/java/nl/lexemmens/podman/enumeration/BuildahCommand.java
+++ b/src/main/java/nl/lexemmens/podman/enumeration/BuildahCommand.java
@@ -1,6 +1,6 @@
 package nl.lexemmens.podman.enumeration;
 
-public enum BuildahCommand {
+public enum BuildahCommand implements Command {
 
     BUILDAH("buildah"),
     UNSHARE("unshare");
@@ -11,6 +11,7 @@ public enum BuildahCommand {
         this.command = command;
     }
 
+    @Override
     public String getCommand() {
         return command;
     }

--- a/src/main/java/nl/lexemmens/podman/enumeration/Command.java
+++ b/src/main/java/nl/lexemmens/podman/enumeration/Command.java
@@ -1,0 +1,13 @@
+package nl.lexemmens.podman.enumeration;
+
+/**
+ * Interface to group all command type enumerations to give {@link nl.lexemmens.podman.service.AbstractExecutorService}
+ * some generic handles to work with and enforce type safety.
+ */
+public interface Command {
+
+    /**
+     * @return The command string represented by this command
+     */
+    String getCommand();
+}

--- a/src/main/java/nl/lexemmens/podman/enumeration/PodmanCommand.java
+++ b/src/main/java/nl/lexemmens/podman/enumeration/PodmanCommand.java
@@ -1,24 +1,44 @@
 package nl.lexemmens.podman.enumeration;
 
-public enum PodmanCommand {
+public enum PodmanCommand implements Command {
 
     PODMAN("podman"),
     LOGIN("login"),
     BUILD("build"),
-    TAG("tag"),
-    SAVE("save"),
+    TAG("tag", false),
+    SAVE("save", false),
     PUSH("push"),
-    RMI("rmi"),
-    VERSION("version");
+    RMI("rmi", false),
+    VERSION("version", false, false);
 
-    private String command;
+    private final String command;
+    private final boolean tlsSupported;
+    private final boolean runRootSupported;
 
     PodmanCommand(String command) {
-        this.command = command;
+        this(command, true, true);
     }
 
+    PodmanCommand(String command, boolean tlsSupported) {
+        this(command, tlsSupported, true);
+    }
+
+    PodmanCommand(String command, boolean tlsSupported, boolean runRootSupported) {
+        this.command = command;
+        this.tlsSupported = tlsSupported;
+        this.runRootSupported = runRootSupported;
+    }
+
+    @Override
     public String getCommand() {
         return command;
     }
 
+    public boolean isTlsSupported() {
+        return tlsSupported;
+    }
+
+    public boolean isRunRootSupported() {
+        return runRootSupported;
+    }
 }

--- a/src/main/java/nl/lexemmens/podman/service/AbstractExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/AbstractExecutorService.java
@@ -1,0 +1,164 @@
+package nl.lexemmens.podman.service;
+
+import nl.lexemmens.podman.enumeration.Command;
+import nl.lexemmens.podman.executor.CommandExecutorDelegate;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.zeroturnaround.exec.ProcessExecutor;
+import org.zeroturnaround.exec.stream.slf4j.Slf4jStream;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>
+ *     Abstract base class to assist realization of a concrete command executor service for commands to be executed.
+ * </p>
+ *
+ * <p>
+ *     This class facilitates the fluent configuration of commands, compiling them to full command lines and delegates
+ *     them to a configured {@link CommandExecutorDelegate} for execution.
+ * </p>
+ *
+ * @param <T> The Type of commands to be handled by this class.
+ */
+public abstract class AbstractExecutorService<T extends Command> {
+    private static final File BASE_DIR = new File(".");
+
+    protected final CommandExecutorDelegate delegate;
+    protected final Log log;
+
+    public AbstractExecutorService(Log log, CommandExecutorDelegate delegate) {
+        this.delegate = delegate;
+        this.log = log;
+    }
+
+    /**
+     * Initiate a command execution by providing the main command to be executed.
+     *
+     * @param command The main command to be executed.
+     * @return A {@link CommandExecutionBuilder} for fluent command configuration.
+     */
+    public CommandExecutionBuilder command(T command) {
+        return new CommandExecutionBuilder(command);
+    }
+
+    /**
+     * <p>
+     *     Compile the full command line from the provided main command and sub commands.
+     * </p>
+     * <p>
+     *     A concrete subclass may further decorate the command line based on static configuration or the type of command
+     * </p>
+     * @param command The main command to be executed.
+     * @param subCommands The configured subCommand to be executed.
+     * @return The compiled full command line.
+     */
+    protected abstract List<String> compileCommandLine(T command, List<String> subCommands);
+
+    /**
+     * This builder class allows for fluent definition and execution of complex commands.
+     */
+    public class CommandExecutionBuilder {
+
+        private final T command;
+        private final List<String> subCommands = new ArrayList<>();
+        private File workDir = BASE_DIR;
+        // As most use-cases demand to redirect the error stream, default is true
+        private boolean redirectError = true;
+        private InputStream inputStream;
+
+        private CommandExecutionBuilder(T command) {
+            this.command = command;
+        }
+
+        /**
+         * Add a subcommand (argument) to the command to be executed.
+         *
+         * @param subcommand the new subcommand to add
+         * @return This builder for further fluent configuration.
+         */
+        public CommandExecutionBuilder subCommand(String subcommand) {
+            subCommands.add(subcommand);
+            return this;
+        }
+
+        /**
+         * Configure the work dir to be anything other than the default current working dir (.)
+         *
+         * @param workDir the new work dir to use
+         * @return This builder for further fluent configuration.
+         */
+        public CommandExecutionBuilder workDir(File workDir) {
+            this.workDir = workDir;
+            return this;
+        }
+
+        /**
+         * <p>
+         *     Configure the process execution to redirect the error stream to the log.
+         * </p>
+         *
+         * <p>
+         *     Default is true when this is not provided.
+         * </p>
+         *
+         * @param redirectError the redirect error value
+         * @return This builder for further fluent configuration.
+         */
+        public CommandExecutionBuilder redirectError(boolean redirectError) {
+            this.redirectError = redirectError;
+            return this;
+        }
+
+        /**
+         * <p>
+         *     Redirect the stdin of the process execution to the provided {@link InputStream}.
+         * </p>
+         *
+         * <p>
+         *     This may be used for instance to provide a password outside of the commandline.
+         * </p>
+         *
+         * @param inputStream the new {@link InputStream}
+         * @return This builder for further fluent configuration.
+         */
+        public CommandExecutionBuilder inputStream(InputStream inputStream) {
+            this.inputStream = inputStream;
+            return this;
+        }
+
+        /**
+         * Terminated the fluent configuration of the command and compile it to be dispatched to the configued
+         * {@link CommandExecutorDelegate}
+         *
+         * @return A {@link List} of {@link String}s representing the actual output of the command
+         * @throws MojoExecutionException In case execution of the command fails
+         */
+        public List<String> run() throws MojoExecutionException {
+            List<String> fullCommand = compileCommandLine(command, subCommands);
+            String msg = String.format("Executing command '%s' from basedir %s", StringUtils.join(fullCommand, " "), BASE_DIR.getAbsolutePath());
+            log.debug(msg);
+            ProcessExecutor processExecutor = new ProcessExecutor()
+                    .directory(workDir)
+                    .command(fullCommand)
+                    .readOutput(true)
+                    .redirectOutput(Slf4jStream.of(getClass().getSimpleName()).asInfo())
+                    .exitValueNormal();
+
+            // Some processes print regular text on stderror, so make redirecting the error stream configurable.
+            if (redirectError) {
+                processExecutor.redirectError(Slf4jStream.of(getClass().getSimpleName()).asError());
+            }
+
+            if (inputStream != null) {
+                processExecutor.redirectInput(inputStream);
+            }
+
+            return delegate.executeCommand(processExecutor);
+        }
+    }
+}

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -26,6 +26,7 @@ import static nl.lexemmens.podman.enumeration.TlsVerify.NOT_SPECIFIED;
 public class PodmanExecutorService {
 
     private static final String SQUASH_CMD = "--squash";
+    private static final String SQUASH_ALL_CMD = "--squash-all";
     private static final String BUILD_FORMAT_CMD = "--format=";
     private static final String LAYERS_CMD = "--layers=";
     private static final String SAVE_FORMAT_CMD = "--format=oci-archive";
@@ -77,11 +78,18 @@ public class PodmanExecutorService {
      */
     public List<String> build(SingleImageConfiguration image) throws MojoExecutionException {
         List<String> subCommand = new ArrayList<>();
-        if(image.getBuild().isSquash()) {
+        if(image.getBuild().getSquash() != null && image.getBuild().getSquash()) {
             subCommand.add(SQUASH_CMD);
         }
 
-        subCommand.add(LAYERS_CMD + image.getBuild().isLayers());
+        if(image.getBuild().getSquashAll() != null && image.getBuild().getSquashAll()) {
+            subCommand.add(SQUASH_ALL_CMD);
+        }
+
+        if(image.getBuild().getLayers() != null && image.getBuild().getLayers()) {
+            subCommand.add(LAYERS_CMD + image.getBuild().getLayers());
+        }
+
         subCommand.add(BUILD_FORMAT_CMD + image.getBuild().getFormat().getValue());
         subCommand.add(CONTAINERFILE_CMD + image.getBuild().getTargetContainerFile());
         subCommand.add(NO_CACHE_CMD + image.getBuild().isNoCache());

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -86,7 +86,7 @@ public class PodmanExecutorService {
             subCommand.add(SQUASH_ALL_CMD);
         }
 
-        if(image.getBuild().getLayers() != null && image.getBuild().getLayers()) {
+        if(image.getBuild().getLayers() != null) {
             subCommand.add(LAYERS_CMD + image.getBuild().getLayers());
         }
 

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -78,11 +78,11 @@ public class PodmanExecutorService {
      */
     public List<String> build(SingleImageConfiguration image) throws MojoExecutionException {
         List<String> subCommand = new ArrayList<>();
-        if(image.getBuild().getSquash() != null && image.getBuild().getSquash()) {
+        if(Boolean.TRUE == image.getBuild().getSquash()) {
             subCommand.add(SQUASH_CMD);
         }
 
-        if(image.getBuild().getSquashAll() != null && image.getBuild().getSquashAll()) {
+        if(Boolean.TRUE == image.getBuild().getSquashAll()) {
             subCommand.add(SQUASH_ALL_CMD);
         }
 

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -25,7 +25,9 @@ import static nl.lexemmens.podman.enumeration.TlsVerify.NOT_SPECIFIED;
  */
 public class PodmanExecutorService {
 
+    private static final String SQUASH_CMD = "--squash";
     private static final String BUILD_FORMAT_CMD = "--format=";
+    private static final String LAYERS_CMD = "--layers=";
     private static final String SAVE_FORMAT_CMD = "--format=oci-archive";
     private static final String OUTPUT_CMD = "--output";
     private static final String CONTAINERFILE_CMD = "--file=";
@@ -43,7 +45,6 @@ public class PodmanExecutorService {
     private final File podmanRoot;
     private final File podmanRunRoot;
     private final File podmanRunDirectory;
-
 
     /**
      * Constructs a new instance of this class.
@@ -76,6 +77,11 @@ public class PodmanExecutorService {
      */
     public List<String> build(SingleImageConfiguration image) throws MojoExecutionException {
         List<String> subCommand = new ArrayList<>();
+        if(image.getBuild().isSquash()) {
+            subCommand.add(SQUASH_CMD);
+        }
+
+        subCommand.add(LAYERS_CMD + image.getBuild().isLayers());
         subCommand.add(BUILD_FORMAT_CMD + image.getBuild().getFormat().getValue());
         subCommand.add(CONTAINERFILE_CMD + image.getBuild().getTargetContainerFile());
         subCommand.add(NO_CACHE_CMD + image.getBuild().isNoCache());

--- a/src/test/java/nl/lexemmens/podman/config/image/single/TestSingleImageConfigurationBuilder.java
+++ b/src/test/java/nl/lexemmens/podman/config/image/single/TestSingleImageConfigurationBuilder.java
@@ -22,6 +22,11 @@ public class TestSingleImageConfigurationBuilder {
         image.setBuild(new SingleImageBuildConfiguration());
     }
 
+    public TestSingleImageConfigurationBuilder setLayers(boolean layers) {
+        image.getBuild().setLayers(layers);
+        return this;
+    }
+
     public TestSingleImageConfigurationBuilder setNoCache(boolean noCache) {
         image.getBuild().setNoCache(noCache);
         return this;
@@ -29,6 +34,16 @@ public class TestSingleImageConfigurationBuilder {
 
     public TestSingleImageConfigurationBuilder setPull(boolean pull) {
         image.getBuild().setPull(pull);
+        return this;
+    }
+
+    public TestSingleImageConfigurationBuilder setSquash(boolean squash) {
+        image.getBuild().setSquash(squash);
+        return this;
+    }
+
+    public TestSingleImageConfigurationBuilder setSquashAll(boolean squashAll) {
+        image.getBuild().setSquashAll(squashAll);
         return this;
     }
 

--- a/src/test/java/nl/lexemmens/podman/service/AuthenticationServiceTest.java
+++ b/src/test/java/nl/lexemmens/podman/service/AuthenticationServiceTest.java
@@ -227,6 +227,7 @@ public class AuthenticationServiceTest {
 
         Path fileToUseAsDockerConfigFile = Paths.get("src", "test", "resources", "validauth.json").toAbsolutePath();
         Path dockerConfigFile = Paths.get(System.getProperty("user.home")).resolve(".docker/config.json");
+        Files.createDirectories(dockerConfigFile.getParent());
         Files.copy(fileToUseAsDockerConfigFile, dockerConfigFile);
 
         AuthenticationService authenticationService = new AuthenticationService(log, podmanExecutorService, settings, settingsDecrypter);

--- a/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
+++ b/src/test/java/nl/lexemmens/podman/service/PodmanExecutorServiceTest.java
@@ -229,6 +229,30 @@ public class PodmanExecutorServiceTest {
                 delegate.getCommandAsString());
     }
 
+
+    @Test
+    public void testBuildNoLayers() throws MojoExecutionException {
+        when(mavenProject.getBuild()).thenReturn(build);
+        when(build.getDirectory()).thenReturn("target");
+
+        PodmanConfiguration podmanConfig = new TestPodmanConfigurationBuilder().setTlsVerify(TRUE).initAndValidate(mavenProject, log).build();
+        SingleImageConfiguration image = new TestSingleImageConfigurationBuilder("test_image")
+                .setFormat(OCI)
+                .setLayers(false)
+                .setContainerfileDir("src/test/resources")
+                .initAndValidate(mavenProject, log, true)
+                .build();
+
+        String sampleImageHash = "this_would_normally_be_an_image_hash";
+        InterceptorCommandExecutorDelegate delegate = new InterceptorCommandExecutorDelegate(Collections.singletonList(sampleImageHash));
+        podmanExecutorService = new PodmanExecutorService(log, podmanConfig, delegate);
+
+        podmanExecutorService.build(image);
+
+        Assertions.assertEquals("podman build --tls-verify=true --layers=false --format=oci --file="
+                + image.getBuild().getTargetContainerFile() + " --no-cache=false .", delegate.getCommandAsString());
+    }
+
     @Test
     public void testBuildPullAlways() throws MojoExecutionException {
         when(mavenProject.getBuild()).thenReturn(build);
@@ -273,6 +297,52 @@ public class PodmanExecutorServiceTest {
 
         Assertions.assertEquals("podman build --tls-verify=true --format=oci --file=" + image.getBuild().getTargetContainerFile() + " --no-cache=false " +
                 "--pull=true .", delegate.getCommandAsString());
+    }
+
+    @Test
+    public void testBuildSquash() throws MojoExecutionException {
+        when(mavenProject.getBuild()).thenReturn(build);
+        when(build.getDirectory()).thenReturn("target");
+
+        PodmanConfiguration podmanConfig = new TestPodmanConfigurationBuilder().setTlsVerify(TRUE).initAndValidate(mavenProject, log).build();
+        SingleImageConfiguration image = new TestSingleImageConfigurationBuilder("test_image")
+                .setFormat(OCI)
+                .setSquash(true)
+                .setContainerfileDir("src/test/resources")
+                .initAndValidate(mavenProject, log, true)
+                .build();
+
+        String sampleImageHash = "this_would_normally_be_an_image_hash";
+        InterceptorCommandExecutorDelegate delegate = new InterceptorCommandExecutorDelegate(Collections.singletonList(sampleImageHash));
+        podmanExecutorService = new PodmanExecutorService(log, podmanConfig, delegate);
+
+        podmanExecutorService.build(image);
+
+        Assertions.assertEquals("podman build --tls-verify=true --squash --format=oci --file="
+                + image.getBuild().getTargetContainerFile() + " --no-cache=false .", delegate.getCommandAsString());
+    }
+
+    @Test
+    public void testBuildSquashAll() throws MojoExecutionException {
+        when(mavenProject.getBuild()).thenReturn(build);
+        when(build.getDirectory()).thenReturn("target");
+
+        PodmanConfiguration podmanConfig = new TestPodmanConfigurationBuilder().setTlsVerify(TRUE).initAndValidate(mavenProject, log).build();
+        SingleImageConfiguration image = new TestSingleImageConfigurationBuilder("test_image")
+                .setFormat(OCI)
+                .setSquashAll(true)
+                .setContainerfileDir("src/test/resources")
+                .initAndValidate(mavenProject, log, true)
+                .build();
+
+        String sampleImageHash = "this_would_normally_be_an_image_hash";
+        InterceptorCommandExecutorDelegate delegate = new InterceptorCommandExecutorDelegate(Collections.singletonList(sampleImageHash));
+        podmanExecutorService = new PodmanExecutorService(log, podmanConfig, delegate);
+
+        podmanExecutorService.build(image);
+
+        Assertions.assertEquals("podman build --tls-verify=true --squash-all --format=oci --file="
+                + image.getBuild().getTargetContainerFile() + " --no-cache=false .", delegate.getCommandAsString());
     }
 
     @Test


### PR DESCRIPTION
Extracted common AbstractExecutorService as new base for both buildah and podman executor services and extended it with fluent command configuration.

Refactored podman login command to use --password-stdin instead of commandline provided password, fixing issue #17

- [ ] To be tested with actual podman login command execution