### PR TITLE
Fixes the unaligned image name when using the %a placeholder

### DIFF
--- a/src/main/java/nl/lexemmens/podman/helper/ImageNameHelper.java
+++ b/src/main/java/nl/lexemmens/podman/helper/ImageNameHelper.java
@@ -96,7 +96,7 @@ public class ImageNameHelper {
 
         @Override
         public String get() {
-            return mavenProject.getArtifactId();
+            return alignWithNamingConvention(mavenProject.getArtifactId());
         }
     }
 

--- a/src/test/java/nl/lexemmens/podman/helper/ImageNameHelperTest.java
+++ b/src/test/java/nl/lexemmens/podman/helper/ImageNameHelperTest.java
@@ -33,7 +33,7 @@ public class ImageNameHelperTest {
 
     @Test
     public void testArtifactIdReplacement() {
-        when(mavenProject.getArtifactId()).thenReturn("my-artifact");
+        when(mavenProject.getArtifactId()).thenReturn("my-Artifact");
 
         SingleImageConfiguration image = new SingleImageConfiguration();
         image.setImageName("sample-image-%a");


### PR DESCRIPTION
This fixes the missing name alignment when using the artifactId placeholder.
The test was modified to have a capital letter to test the alignment.