### PR TITLE
Update the PushMojo to use the container-catalog for pushing images

### DIFF
--- a/docs/modules/ROOT/pages/goals/push.adoc
+++ b/docs/modules/ROOT/pages/goals/push.adoc
@@ -5,6 +5,8 @@
 
 This goal uploads images to the registry which have a `<build>` configuration section. The default registry where images are pushed to is docker.io, but can be specified as part of the images’s name the Docker way. E.g. `containers.host.com:12345/sample:1.2` will push the image data with tag 1.2 to the registry `containers.host.com` at port 12345. Security information (i.e. user and password) can be specified as described in section xref:authentication.adoc[].
 
+NOTE: It is required to have the `build` goal executed in order to execute the `push` goal without manual intervention.
+
 .Push options
 |===
 |Element |Description |Property

--- a/src/main/java/nl/lexemmens/podman/AbstractCatalogSupport.java
+++ b/src/main/java/nl/lexemmens/podman/AbstractCatalogSupport.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public abstract class AbstractUploadMojo extends AbstractPodmanMojo {
+public abstract class AbstractCatalogSupport extends AbstractPodmanMojo {
 
     @Parameter(defaultValue = "${repositorySystemSession}", required = true)
     public RepositorySystemSession repositorySystemSession;

--- a/src/main/java/nl/lexemmens/podman/AbstractUploadMojo.java
+++ b/src/main/java/nl/lexemmens/podman/AbstractUploadMojo.java
@@ -43,7 +43,7 @@ public abstract class AbstractUploadMojo extends AbstractPodmanMojo {
     protected List<String> readLocalCatalog() throws MojoExecutionException {
         String catalogFileName = String.format("%s.txt", CATALOG_ARTIFACT_NAME);
         Path catalogPath = Paths.get(project.getBuild().getDirectory(), catalogFileName);
-        return readCatalogContent(catalogPath);
+        return readCatalogContent(catalogPath, true);
     }
 
     protected List<String> readRemoteCatalog(RepositorySystemSession repositorySystemSession) throws MojoExecutionException {
@@ -66,7 +66,7 @@ public abstract class AbstractUploadMojo extends AbstractPodmanMojo {
                         "queried, but no such artifact was returned.");
             }
             if (artifactResult.isResolved()) {
-                return readCatalogContent(Paths.get(artifactResult.getArtifact().getFile().toURI()));
+                return readCatalogContent(Paths.get(artifactResult.getArtifact().getFile().toURI()), false);
             } else {
                 throw new MojoExecutionException("Failed to resolve the container catalog file.");
             }
@@ -76,12 +76,15 @@ public abstract class AbstractUploadMojo extends AbstractPodmanMojo {
         }
     }
 
-    private List<String> readCatalogContent(Path catalogPath) throws MojoExecutionException {
+    private List<String> readCatalogContent(Path catalogPath, boolean local) throws MojoExecutionException {
         try (Stream<String> catalogStream = Files.lines(catalogPath)) {
             return catalogStream.skip(1)
                     .collect(Collectors.toList());
         } catch (IOException e) {
             String msg = "Failed to read container catalog.";
+            if (local) {
+                msg += " Make sure the build goal is executed.";
+            }
             getLog().error(msg);
             throw new MojoExecutionException(msg, e);
         }

--- a/src/main/java/nl/lexemmens/podman/AbstractUploadMojo.java
+++ b/src/main/java/nl/lexemmens/podman/AbstractUploadMojo.java
@@ -140,8 +140,8 @@ public abstract class AbstractUploadMojo extends AbstractPodmanMojo {
     }
 
     public static final class PodmanSession {
-        public DefaultRepositorySystemSession session;
-        public File repo;
+        public final DefaultRepositorySystemSession session;
+        public final File repo;
 
         public PodmanSession(DefaultRepositorySystemSession session, File repo) {
             this.session = session;

--- a/src/main/java/nl/lexemmens/podman/AbstractUploadMojo.java
+++ b/src/main/java/nl/lexemmens/podman/AbstractUploadMojo.java
@@ -1,0 +1,149 @@
+package nl.lexemmens.podman;
+
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public abstract class AbstractUploadMojo extends AbstractPodmanMojo {
+
+    @Parameter(defaultValue = "${repositorySystemSession}", required = true)
+    public RepositorySystemSession repositorySystemSession;
+
+    @Component
+    public EnhancedLocalRepositoryManagerFactory localRepositoryManagerFactory;
+
+    @Component
+    public RepositorySystem repositorySystem;
+
+    protected List<String> readLocalCatalog() throws MojoExecutionException {
+        String catalogFileName = String.format("%s.txt", CATALOG_ARTIFACT_NAME);
+        Path catalogPath = Paths.get(project.getBuild().getDirectory(), catalogFileName);
+        return readCatalogContent(catalogPath);
+    }
+
+    protected List<String> readRemoteCatalog(RepositorySystemSession repositorySystemSession) throws MojoExecutionException {
+        List<RemoteRepository> remoteRepositories = getRemoteRepositories();
+
+        try {
+            DefaultArtifact artifact = new DefaultArtifact(
+                    project.getGroupId(),
+                    project.getArtifactId(),
+                    CATALOG_ARTIFACT_NAME,
+                    "txt",
+                    project.getVersion()
+            );
+
+            ArtifactRequest artifactRequest = new ArtifactRequest(artifact, remoteRepositories, null);
+
+            ArtifactResult artifactResult = repositorySystem.resolveArtifact(repositorySystemSession, artifactRequest);
+            if (artifactResult.isMissing()) {
+                throw new MojoExecutionException("Cannot find container catalog. All repositories were successfully " +
+                        "queried, but no such artifact was returned.");
+            }
+            if (artifactResult.isResolved()) {
+                return readCatalogContent(Paths.get(artifactResult.getArtifact().getFile().toURI()));
+            } else {
+                throw new MojoExecutionException("Failed to resolve the container catalog file.");
+            }
+
+        } catch (ArtifactResolutionException e) {
+            throw new MojoExecutionException("Failed retrieving container catalog file", e);
+        }
+    }
+
+    private List<String> readCatalogContent(Path catalogPath) throws MojoExecutionException {
+        try (Stream<String> catalogStream = Files.lines(catalogPath)) {
+            return catalogStream.skip(1)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            String msg = "Failed to read container catalog.";
+            getLog().error(msg);
+            throw new MojoExecutionException(msg, e);
+        }
+    }
+
+    protected List<RemoteRepository> getRemoteRepositories() throws MojoExecutionException {
+        List<ArtifactRepository> remoteArtifactRepositories;
+        String sourceCatalogRepository = skopeo.getCopy().getSourceCatalogRepository();
+
+        if (sourceCatalogRepository == null) {
+            getLog().info("Using all remote repositories to find container catalog.");
+            remoteArtifactRepositories = project.getRemoteArtifactRepositories();
+        } else {
+            Optional<ArtifactRepository> repository = project.getRemoteArtifactRepositories()
+                    .stream()
+                    .filter(repo -> repo.getId().equals(sourceCatalogRepository))
+                    .findFirst();
+            if (repository.isPresent()) {
+                getLog().info("Using repository " + repository.get() + " for finding container catalog.");
+                remoteArtifactRepositories = new ArrayList<>();
+                remoteArtifactRepositories.add(repository.get());
+            } else if (skopeo.getCopy().getDisableLocal()) {
+                throw new MojoExecutionException("Cannot resolve artifacts from 'null' repository if the local repository is also disabled.");
+            } else {
+                getLog().debug("Resolving container images via catalog from local repository only.");
+                remoteArtifactRepositories = new ArrayList<>();
+            }
+        }
+
+        return RepositoryUtils.toRepos(remoteArtifactRepositories);
+    }
+
+    protected PodmanSession getTempSession(boolean disableLocalRepo) {
+        // Use a customized repository session, setup to force a few behaviors we like.
+        DefaultRepositorySystemSession tempSession = new DefaultRepositorySystemSession(repositorySystemSession);
+        tempSession.setUpdatePolicy(RepositoryPolicy.UPDATE_POLICY_ALWAYS);
+
+        File tempRepo = null;
+        if (disableLocalRepo) {
+            getLog().info("Disabling local repository @ " + tempSession.getLocalRepository().getBasedir());
+            try {
+                tempRepo = Files.createTempDirectory("podman-maven-plugin-repo").toFile();
+
+                getLog().info("Using temporary local repository @ " + tempRepo.getAbsolutePath());
+                tempSession.setLocalRepositoryManager(localRepositoryManagerFactory.newInstance(tempSession, new LocalRepository(tempRepo)));
+            } catch (IOException | NoLocalRepositoryManagerException e) {
+                getLog().warn("Failed to disable local repository path.", e);
+            }
+        }
+        tempSession.setReadOnly();
+
+        return new PodmanSession(tempSession, tempRepo);
+    }
+
+    public static final class PodmanSession {
+        public DefaultRepositorySystemSession session;
+        public File repo;
+
+        public PodmanSession(DefaultRepositorySystemSession session, File repo) {
+            this.session = session;
+            this.repo = repo;
+        }
+    }
+
+}

--- a/src/main/java/nl/lexemmens/podman/BuildMojo.java
+++ b/src/main/java/nl/lexemmens/podman/BuildMojo.java
@@ -36,8 +36,7 @@ public class BuildMojo extends AbstractPodmanMojo {
     @Parameter(property = "podman.skip.tag", defaultValue = "false")
     boolean skipTag;
     /**
-     * Indicates if container images should be catalogued in a separate container-catalog.txt file
-     * that is attached to the build.
+     * Indicates if attaching the container-catalog.txt file to the build should be skipped.
      */
     @Parameter(property = "podman.skip.catalog", defaultValue = "false")
     boolean skipCatalog;
@@ -74,11 +73,7 @@ public class BuildMojo extends AbstractPodmanMojo {
             getLog().info("Built container image.");
         }
 
-        if (skipCatalog) {
-            getLog().info("Skipping cataloguing container images.");
-        } else {
-            catalogContainers(resolvedImages, hub);
-        }
+        catalogContainers(resolvedImages, hub);
     }
 
     private void decorateContainerfile(SingleImageConfiguration image, ServiceHub hub) throws MojoExecutionException {
@@ -174,9 +169,13 @@ public class BuildMojo extends AbstractPodmanMojo {
             throw new MojoExecutionException(e.getMessage(), e);
         }
 
-        getLog().info("Attaching catalog artifact: " + catalogPath);
+        if (skipCatalog) {
+            getLog().info("Skipping attaching of catalog artifact.");
+        } else {
+            getLog().info("Attaching catalog artifact: " + catalogPath);
 
-        hub.getMavenProjectHelper().attachArtifact(project, "txt", CATALOG_ARTIFACT_NAME, catalogPath.toFile());
+            hub.getMavenProjectHelper().attachArtifact(project, "txt", CATALOG_ARTIFACT_NAME, catalogPath.toFile());
+        }
     }
 
     private List<String> getContainerCatalog(List<SingleImageConfiguration> images) {

--- a/src/main/java/nl/lexemmens/podman/CopyMojo.java
+++ b/src/main/java/nl/lexemmens/podman/CopyMojo.java
@@ -18,7 +18,7 @@ import java.util.Map;
  * to another.
  */
 @Mojo(name = "copy", defaultPhase = LifecyclePhase.DEPLOY)
-public class CopyMojo extends AbstractUploadMojo {
+public class CopyMojo extends AbstractCatalogSupport {
 
     /**
      * Indicates if building container images should be skipped

--- a/src/main/java/nl/lexemmens/podman/CopyMojo.java
+++ b/src/main/java/nl/lexemmens/podman/CopyMojo.java
@@ -6,7 +6,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.eclipse.aether.repository.RemoteRepository;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/nl/lexemmens/podman/CopyMojo.java
+++ b/src/main/java/nl/lexemmens/podman/CopyMojo.java
@@ -2,60 +2,30 @@ package nl.lexemmens.podman;
 
 import nl.lexemmens.podman.service.ServiceHub;
 import org.apache.commons.io.FileUtils;
-import org.apache.maven.RepositoryUtils;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
-import org.eclipse.aether.repository.LocalRepository;
-import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
 import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.repository.RepositoryPolicy;
-import org.eclipse.aether.resolution.ArtifactRequest;
-import org.eclipse.aether.resolution.ArtifactResolutionException;
-import org.eclipse.aether.resolution.ArtifactResult;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Executes a Skopeo copy command, that allows to copy containers from one location
  * to another.
  */
 @Mojo(name = "copy", defaultPhase = LifecyclePhase.DEPLOY)
-public class CopyMojo extends AbstractPodmanMojo {
+public class CopyMojo extends AbstractUploadMojo {
 
     /**
      * Indicates if building container images should be skipped
      */
     @Parameter(property = "skopeo.skip.copy", defaultValue = "false")
     boolean skipCopy;
-
-    @Parameter(defaultValue = "${repositorySystemSession}", required = true)
-    RepositorySystemSession repositorySystemSession;
-
-    @Component
-    EnhancedLocalRepositoryManagerFactory localRepositoryManagerFactory;
-
-    @Component
-    RepositorySystem repositorySystem;
 
     @Override
     public void executeInternal(ServiceHub hub) throws MojoExecutionException {
@@ -82,25 +52,10 @@ public class CopyMojo extends AbstractPodmanMojo {
         getLog().info("Using container-catalog.txt to perform Skopeo copy.");
 
         // Use a customized repository session, setup to force a few behaviors we like.
-        DefaultRepositorySystemSession tempSession = new DefaultRepositorySystemSession(repositorySystemSession);
-        tempSession.setUpdatePolicy(RepositoryPolicy.UPDATE_POLICY_ALWAYS);
+        PodmanSession tempSession = getTempSession(skopeo.getCopy().getDisableLocal());
+        File tempRepo = tempSession.repo;
 
-        File tempRepo = null;
-        if (skopeo.getCopy().getDisableLocal()) {
-            getLog().info("Disabling local repository @ " + tempSession.getLocalRepository().getBasedir());
-            try {
-                tempRepo = Files.createTempDirectory("podman-maven-plugin-repo").toFile();
-
-                getLog().info("Using temporary local repository @ " + tempRepo.getAbsolutePath());
-                tempSession.setLocalRepositoryManager(localRepositoryManagerFactory.newInstance(tempSession, new LocalRepository(tempRepo)));
-            } catch (IOException | NoLocalRepositoryManagerException e) {
-                getLog().warn("Failed to disable local repository path.", e);
-            }
-        }
-        tempSession.setReadOnly();
-
-        List<RemoteRepository> remoteRepositories = getRemoteRepositories();
-        List<String> cataloguedImages = getCatalog(tempSession, remoteRepositories);
+        List<String> cataloguedImages = readRemoteCatalog(tempSession.session);
         Map<String, String> transformedImages = performTransformation(cataloguedImages);
 
         for (Map.Entry<String, String> imageEntry : transformedImages.entrySet()) {
@@ -113,66 +68,6 @@ public class CopyMojo extends AbstractPodmanMojo {
             } catch (IOException e) {
                 getLog().warn("Failed to cleanup temporary repository directory: " + tempRepo);
             }
-        }
-    }
-
-    private List<RemoteRepository> getRemoteRepositories() throws MojoExecutionException {
-        List<ArtifactRepository> remoteArtifactRepositories;
-        String sourceCatalogRepository = skopeo.getCopy().getSourceCatalogRepository();
-
-        if (sourceCatalogRepository == null) {
-            getLog().info("Using all remote repositories to find container catalog.");
-            remoteArtifactRepositories = project.getRemoteArtifactRepositories();
-        } else {
-            Optional<ArtifactRepository> repository = project.getRemoteArtifactRepositories()
-                    .stream()
-                    .filter(repo -> repo.getId().equals(sourceCatalogRepository))
-                    .findFirst();
-            if (repository.isPresent()) {
-                getLog().info("Using repository " + repository.get() + " for finding container catalog.");
-                remoteArtifactRepositories = new ArrayList<>();
-                remoteArtifactRepositories.add(repository.get());
-            } else if (skopeo.getCopy().getDisableLocal()) {
-                throw new MojoExecutionException("Cannot resolve artifacts from 'null' repository if the local repository is also disabled.");
-            } else {
-                getLog().debug("Resolving container images via catalog from local repository only.");
-                remoteArtifactRepositories = new ArrayList<>();
-            }
-        }
-
-        return RepositoryUtils.toRepos(remoteArtifactRepositories);
-    }
-
-    private List<String> getCatalog(RepositorySystemSession repositorySystemSession, List<RemoteRepository> remoteRepositories) throws MojoExecutionException {
-        try {
-            DefaultArtifact artifact = new DefaultArtifact(
-                    project.getGroupId(),
-                    project.getArtifactId(),
-                    CATALOG_ARTIFACT_NAME,
-                    "txt",
-                    project.getVersion()
-            );
-
-            ArtifactRequest artifactRequest = new ArtifactRequest(artifact, remoteRepositories, null);
-
-            ArtifactResult artifactResult = repositorySystem.resolveArtifact(repositorySystemSession, artifactRequest);
-            if (artifactResult.isMissing()) {
-                throw new MojoExecutionException("Cannot find container catalog. All repositories were successfully " +
-                        "queried, but no such artifact was returned.");
-            }
-            if (artifactResult.isResolved()) {
-                Path resolvedArtifactPath = Paths.get(artifactResult.getArtifact().getFile().toURI());
-                try (Stream<String> catalogStream = Files.lines(resolvedArtifactPath)) {
-                    return catalogStream.skip(1).collect(Collectors.toList());
-                } catch (IOException e) {
-                    throw new MojoExecutionException("Failed to read container catalog.", e);
-                }
-            } else {
-                throw new MojoExecutionException("Failed to resolve the container catalog file.");
-            }
-
-        } catch (ArtifactResolutionException e) {
-            throw new MojoExecutionException("Failed retrieving container catalog file", e);
         }
     }
 

--- a/src/main/java/nl/lexemmens/podman/PushMojo.java
+++ b/src/main/java/nl/lexemmens/podman/PushMojo.java
@@ -12,7 +12,7 @@ import java.util.List;
  * PushMojo for pushing container images to a registry/repository
  */
 @Mojo(name = "push", defaultPhase = LifecyclePhase.DEPLOY)
-public class PushMojo extends AbstractUploadMojo {
+public class PushMojo extends AbstractCatalogSupport {
 
     /**
      * Indicates if building container images should be skipped

--- a/src/main/java/nl/lexemmens/podman/PushMojo.java
+++ b/src/main/java/nl/lexemmens/podman/PushMojo.java
@@ -5,7 +5,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.eclipse.aether.repository.RemoteRepository;
 
 import java.util.List;
 

--- a/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
@@ -593,7 +593,6 @@ public class BuildMojoTest extends AbstractMojoTest {
         when(serviceHubFactory.createServiceHub(isA(Log.class), isA(MavenProject.class), isA(MavenFileFilter.class), isA(PodmanConfiguration.class), isA(SkopeoConfiguration.class), isA(Settings.class), isA(SettingsDecrypter.class), isA(MavenProjectHelper.class))).thenReturn(serviceHub);
         when(serviceHub.getContainerfileDecorator()).thenReturn(containerfileDecorator);
         when(serviceHub.getPodmanExecutorService()).thenReturn(podmanExecutorService);
-        when(serviceHub.getMavenProjectHelper()).thenReturn(mavenProjectHelper);
         when(podmanExecutorService.build(isA(SingleImageConfiguration.class))).thenReturn(buildOutputUnderTest);
 
         buildMojo.execute();

--- a/src/test/java/nl/lexemmens/podman/CleanMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/CleanMojoTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -40,7 +39,7 @@ public class CleanMojoTest extends AbstractMojoTest {
 
         cleanMojo.execute();
 
-        verify(log, times(1)).info(Mockito.eq("Podman actions are skipped."));
+        verify(log, times(1)).info("Podman actions are skipped.");
     }
 
     @Test
@@ -49,7 +48,7 @@ public class CleanMojoTest extends AbstractMojoTest {
 
         cleanMojo.execute();
 
-        verify(log, times(1)).info(Mockito.eq("Cleaning local storage is skipped."));
+        verify(log, times(1)).info("Cleaning local storage is skipped.");
     }
 
     @Test
@@ -58,7 +57,7 @@ public class CleanMojoTest extends AbstractMojoTest {
 
         cleanMojo.execute();
 
-        verify(log, times(1)).info(Mockito.eq("Not cleaning up local storage as default storage location is being used."));
+        verify(log, times(1)).info("Not cleaning up local storage as default storage location is being used.");
     }
 
     @Test
@@ -72,7 +71,7 @@ public class CleanMojoTest extends AbstractMojoTest {
 
         cleanMojo.execute();
 
-        verify(log, times(1)).info(Mockito.eq("Cleaning up " + customRoot.getAbsolutePath() + "..."));
+        verify(log, times(1)).info("Cleaning up " + customRoot.getAbsolutePath() + "...");
         verify(serviceHub, times(1)).getBuildahExecutorService();
         verify(buildahExecutorService, times(1)).cleanupLocalContainerStorage();
     }

--- a/src/test/java/nl/lexemmens/podman/CopyMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/CopyMojoTest.java
@@ -190,10 +190,8 @@ public class CopyMojoTest extends AbstractMojoTest {
             try {
                 if (Files.isDirectory(path)) {
                     cleanDir(path);
-                    Files.delete(path);
-                } else {
-                    Files.delete(path);
                 }
+                Files.delete(path);
             } catch (IOException e) {
                 ioExceptions.add(e);
             }

--- a/src/test/java/nl/lexemmens/podman/PushMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/PushMojoTest.java
@@ -111,7 +111,7 @@ public class PushMojoTest extends AbstractMojoTest {
         Assertions.assertThrows(MojoExecutionException.class, pushMojo::execute);
 
         verify(log, Mockito.times(1)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, Mockito.times(1)).error(Mockito.eq("Failed to read container catalog."));
+        verify(log, Mockito.times(1)).error(Mockito.eq("Failed to read container catalog. Make sure the build goal is executed."));
     }
 
     @Test

--- a/src/test/java/nl/lexemmens/podman/PushMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/PushMojoTest.java
@@ -24,9 +24,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -76,7 +74,7 @@ public class PushMojoTest extends AbstractMojoTest {
 
         pushMojo.execute();
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Podman actions are skipped."));
+        verify(log, Mockito.times(1)).info("Podman actions are skipped.");
     }
 
     @Test
@@ -93,7 +91,7 @@ public class PushMojoTest extends AbstractMojoTest {
 
         pushMojo.execute();
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Pushing container images is skipped."));
+        verify(log, Mockito.times(1)).info("Pushing container images is skipped.");
     }
 
     @Test
@@ -110,8 +108,8 @@ public class PushMojoTest extends AbstractMojoTest {
 
         Assertions.assertThrows(MojoExecutionException.class, pushMojo::execute);
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, Mockito.times(1)).error(Mockito.eq("Failed to read container catalog. Make sure the build goal is executed."));
+        verify(log, Mockito.times(1)).info("Registry authentication is skipped.");
+        verify(log, Mockito.times(1)).error("Failed to read container catalog. Make sure the build goal is executed.");
     }
 
     @Test
@@ -130,10 +128,10 @@ public class PushMojoTest extends AbstractMojoTest {
 
         Assertions.assertThrows(MojoExecutionException.class, pushMojo::execute);
 
-        verify(log, times(1)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, times(0)).info(Mockito.eq("Pushing container images is skipped."));
-        verify(log, times(0)).info(Mockito.eq("No tags specified. Will not push container images."));
-        verify(log, times(1)).error(Mockito.eq("Failed to push container images. No registry specified. Configure the registry by adding the <pushRegistry><!-- registry --></pushRegistry> tag to your configuration."));
+        verify(log, times(1)).info("Registry authentication is skipped.");
+        verify(log, times(0)).info("Pushing container images is skipped.");
+        verify(log, times(0)).info("No tags specified. Will not push container images.");
+        verify(log, times(1)).error("Failed to push container images. No registry specified. Configure the registry by adding the <pushRegistry><!-- registry --></pushRegistry> tag to your configuration.");
 
     }
 
@@ -152,14 +150,14 @@ public class PushMojoTest extends AbstractMojoTest {
         when(mavenProject.getVersion()).thenReturn("1.0.0");
         when(serviceHubFactory.createServiceHub(isA(Log.class), isA(MavenProject.class), isA(MavenFileFilter.class), isA(PodmanConfiguration.class), isA(SkopeoConfiguration.class), isA(Settings.class), isA(SettingsDecrypter.class), isA(MavenProjectHelper.class))).thenReturn(serviceHub);
         when(serviceHub.getPodmanExecutorService()).thenReturn(podmanExecutorService);
-        doNothing().when(podmanExecutorService).push(eq(targetRegistry));
+        doNothing().when(podmanExecutorService).push(targetRegistry);
 
         Assertions.assertDoesNotThrow(pushMojo::execute);
 
-        verify(log, times(1)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, times(0)).info(Mockito.eq("Pushing container images is skipped."));
-        verify(log, times(0)).info(Mockito.eq("No tags specified. Will not push container images."));
-        verify(podmanExecutorService, times(1)).push(eq(targetRegistry));
+        verify(log, times(1)).info("Registry authentication is skipped.");
+        verify(log, times(0)).info("Pushing container images is skipped.");
+        verify(log, times(0)).info("No tags specified. Will not push container images.");
+        verify(podmanExecutorService, times(1)).push(targetRegistry);
     }
 
     @Test
@@ -180,15 +178,15 @@ public class PushMojoTest extends AbstractMojoTest {
         when(mavenProject.getVersion()).thenReturn("1.0.0");
         when(serviceHubFactory.createServiceHub(isA(Log.class), isA(MavenProject.class), isA(MavenFileFilter.class), isA(PodmanConfiguration.class), isA(SkopeoConfiguration.class), isA(Settings.class), isA(SettingsDecrypter.class), isA(MavenProjectHelper.class))).thenReturn(serviceHub);
         when(serviceHub.getPodmanExecutorService()).thenReturn(podmanExecutorService);
-        doNothing().when(podmanExecutorService).push(eq(targetRegistry));
+        doNothing().when(podmanExecutorService).push(targetRegistry);
         when(serviceHub.getAuthenticationService()).thenReturn(authenticationService);
 
         Assertions.assertDoesNotThrow(pushMojo::execute);
 
-        verify(log, times(0)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, times(0)).info(Mockito.eq("Pushing container images is skipped."));
-        verify(log, times(0)).info(Mockito.eq("No tags specified. Will not push container images."));
-        verify(podmanExecutorService, times(1)).push(eq(targetRegistry));
+        verify(log, times(0)).info("Registry authentication is skipped.");
+        verify(log, times(0)).info("Pushing container images is skipped.");
+        verify(log, times(0)).info("No tags specified. Will not push container images.");
+        verify(podmanExecutorService, times(1)).push(targetRegistry);
     }
 
     @Test
@@ -210,15 +208,15 @@ public class PushMojoTest extends AbstractMojoTest {
         when(mavenProject.getVersion()).thenReturn("1.0.0");
         when(serviceHubFactory.createServiceHub(isA(Log.class), isA(MavenProject.class), isA(MavenFileFilter.class), isA(PodmanConfiguration.class), isA(SkopeoConfiguration.class), isA(Settings.class), isA(SettingsDecrypter.class), isA(MavenProjectHelper.class))).thenReturn(serviceHub);
         when(serviceHub.getPodmanExecutorService()).thenReturn(podmanExecutorService);
-        doNothing().when(podmanExecutorService).push(eq(targetRegistry));
+        doNothing().when(podmanExecutorService).push(targetRegistry);
         when(serviceHub.getAuthenticationService()).thenReturn(authenticationService);
 
         Assertions.assertDoesNotThrow(pushMojo::execute);
 
-        verify(log, times(0)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, times(0)).info(Mockito.eq("Pushing container images is skipped."));
-        verify(log, times(0)).info(Mockito.eq("No tags specified. Will not push container images."));
-        verify(podmanExecutorService, times(1)).push(eq(targetRegistry));
+        verify(log, times(0)).info("Registry authentication is skipped.");
+        verify(log, times(0)).info("Pushing container images is skipped.");
+        verify(log, times(0)).info("No tags specified. Will not push container images.");
+        verify(podmanExecutorService, times(1)).push(targetRegistry);
         verify(podmanExecutorService, times(1)).version();
     }
 
@@ -240,17 +238,17 @@ public class PushMojoTest extends AbstractMojoTest {
         when(mavenProject.getVersion()).thenReturn("1.0.0");
         when(serviceHubFactory.createServiceHub(isA(Log.class), isA(MavenProject.class), isA(MavenFileFilter.class), isA(PodmanConfiguration.class), isA(SkopeoConfiguration.class), isA(Settings.class), isA(SettingsDecrypter.class), isA(MavenProjectHelper.class))).thenReturn(serviceHub);
         when(serviceHub.getPodmanExecutorService()).thenReturn(podmanExecutorService);
-        doNothing().when(podmanExecutorService).push(eq(imageName));
-        doNothing().when(podmanExecutorService).removeLocalImage(eq(imageName));
+        doNothing().when(podmanExecutorService).push(imageName);
+        doNothing().when(podmanExecutorService).removeLocalImage(imageName);
 
         Assertions.assertDoesNotThrow(pushMojo::execute);
 
-        verify(log, times(1)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, times(0)).info(Mockito.eq("Pushing container images is skipped."));
-        verify(log, times(0)).info(Mockito.eq("No tags specified. Will not push container images."));
-        verify(log, times(1)).info(Mockito.eq("Removing image " + imageName + " from the local repository"));
-        verify(podmanExecutorService, times(1)).push(eq(imageName));
-        verify(podmanExecutorService, times(1)).removeLocalImage(eq(imageName));
+        verify(log, times(1)).info("Registry authentication is skipped.");
+        verify(log, times(0)).info("Pushing container images is skipped.");
+        verify(log, times(0)).info("No tags specified. Will not push container images.");
+        verify(log, times(1)).info("Removing image " + imageName + " from the local repository");
+        verify(podmanExecutorService, times(1)).push(imageName);
+        verify(podmanExecutorService, times(1)).removeLocalImage(imageName);
     }
 
     @Test
@@ -270,11 +268,11 @@ public class PushMojoTest extends AbstractMojoTest {
         pushMojo.execute();
 
         // Verify logging
-        verify(log, times(1)).info(Mockito.eq("Pushing container images to registry ..."));
-        verify(log, times(1)).info(Mockito.eq("Pushing image: registry.example.com/sample:1.0.0 to registry.example.com"));
-        verify(podmanExecutorService, times(1)).push(eq("registry.example.com/sample:1.0.0"));
-        verify(log, times(1)).info(Mockito.eq("Successfully pushed container image registry.example.com/sample:1.0.0 to registry.example.com"));
-        verify(log, times(1)).info(Mockito.eq("All images have been successfully pushed to the registry"));
+        verify(log, times(1)).info("Pushing container images to registry ...");
+        verify(log, times(1)).info("Pushing image: registry.example.com/sample:1.0.0 to registry.example.com");
+        verify(podmanExecutorService, times(1)).push("registry.example.com/sample:1.0.0");
+        verify(log, times(1)).info("Successfully pushed container image registry.example.com/sample:1.0.0 to registry.example.com");
+        verify(log, times(1)).info("All images have been successfully pushed to the registry");
     }
 
     @Test
@@ -297,17 +295,17 @@ public class PushMojoTest extends AbstractMojoTest {
         pushMojo.execute();
 
         /// Verify logging
-        verify(log, times(1)).info(Mockito.eq("Pushing container images to registry ..."));
+        verify(log, times(1)).info("Pushing container images to registry ...");
 
-        verify(log, times(1)).info(Mockito.eq("Pushing image: registry.example.com/image-name-number-1:0.2.1 to registry.example.com"));
-        verify(podmanExecutorService, times(1)).push(eq("registry.example.com/image-name-number-1:0.2.1"));
-        verify(log, times(1)).info(Mockito.eq("Successfully pushed container image registry.example.com/image-name-number-1:0.2.1 to registry.example.com"));
+        verify(log, times(1)).info("Pushing image: registry.example.com/image-name-number-1:0.2.1 to registry.example.com");
+        verify(podmanExecutorService, times(1)).push("registry.example.com/image-name-number-1:0.2.1");
+        verify(log, times(1)).info("Successfully pushed container image registry.example.com/image-name-number-1:0.2.1 to registry.example.com");
 
-        verify(log, times(1)).info(Mockito.eq("Pushing image: registry.example.com/image-name-number-2:0.2.1 to registry.example.com"));
-        verify(podmanExecutorService, times(1)).push(eq("registry.example.com/image-name-number-2:0.2.1"));
-        verify(log, times(1)).info(Mockito.eq("Successfully pushed container image registry.example.com/image-name-number-2:0.2.1 to registry.example.com"));
+        verify(log, times(1)).info("Pushing image: registry.example.com/image-name-number-2:0.2.1 to registry.example.com");
+        verify(podmanExecutorService, times(1)).push("registry.example.com/image-name-number-2:0.2.1");
+        verify(log, times(1)).info("Successfully pushed container image registry.example.com/image-name-number-2:0.2.1 to registry.example.com");
 
-        verify(log, times(1)).info(Mockito.eq("All images have been successfully pushed to the registry"));
+        verify(log, times(1)).info("All images have been successfully pushed to the registry");
     }
 
     @Test
@@ -329,14 +327,14 @@ public class PushMojoTest extends AbstractMojoTest {
         // Simulate failure
         doThrow(new MojoExecutionException("Execution failed"))
                 .doNothing()
-                .when(podmanExecutorService).push(eq(targetRegistry));
+                .when(podmanExecutorService).push(targetRegistry);
 
         Assertions.assertDoesNotThrow(pushMojo::execute);
 
-        verify(log, times(1)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, times(0)).info(Mockito.eq("Pushing container images is skipped."));
-        verify(log, times(0)).info(Mockito.eq("No tags specified. Will not push container images."));
-        verify(podmanExecutorService, times(2)).push(eq(targetRegistry));
+        verify(log, times(1)).info("Registry authentication is skipped.");
+        verify(log, times(0)).info("Pushing container images is skipped.");
+        verify(log, times(0)).info("No tags specified. Will not push container images.");
+        verify(podmanExecutorService, times(2)).push(targetRegistry);
     }
 
     @Test
@@ -356,14 +354,14 @@ public class PushMojoTest extends AbstractMojoTest {
         when(serviceHub.getPodmanExecutorService()).thenReturn(podmanExecutorService);
 
         // Simulate failure
-        doThrow(new MojoExecutionException("Execution failed")).when(podmanExecutorService).push(eq(targetRegistry));
+        doThrow(new MojoExecutionException("Execution failed")).when(podmanExecutorService).push(targetRegistry);
 
         Assertions.assertThrows(MojoExecutionException.class, pushMojo::execute);
 
-        verify(log, times(1)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, times(0)).info(Mockito.eq("Pushing container images is skipped."));
-        verify(log, times(0)).info(Mockito.eq("No tags specified. Will not push container images."));
-        verify(podmanExecutorService, times(2)).push(eq(targetRegistry));
+        verify(log, times(1)).info("Registry authentication is skipped.");
+        verify(log, times(0)).info("Pushing container images is skipped.");
+        verify(log, times(0)).info("No tags specified. Will not push container images.");
+        verify(podmanExecutorService, times(2)).push(targetRegistry);
     }
 
     private void configureMojo(SingleImageConfiguration image, boolean skipAuth, boolean skipAll, boolean skipPush, String targetRegistry, boolean deleteLocalImageAfterPush, boolean failOnMissingContainerFile, int retries) {

--- a/src/test/java/nl/lexemmens/podman/SaveMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/SaveMojoTest.java
@@ -50,7 +50,7 @@ public class SaveMojoTest extends AbstractMojoTest {
 
         saveMojo.execute();
 
-        verify(log, times(1)).info(Mockito.eq("Podman actions are skipped."));
+        verify(log, times(1)).info("Podman actions are skipped.");
     }
 
     @Test
@@ -66,7 +66,7 @@ public class SaveMojoTest extends AbstractMojoTest {
 
         saveMojo.execute();
 
-        verify(log, times(1)).info(Mockito.eq("Saving container images is skipped."));
+        verify(log, times(1)).info("Saving container images is skipped.");
     }
 
     @Test
@@ -82,8 +82,8 @@ public class SaveMojoTest extends AbstractMojoTest {
 
         Assertions.assertDoesNotThrow(saveMojo::execute);
 
-        verify(log, times(1)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, times(0)).info(Mockito.eq("Saving container images is skipped."));
+        verify(log, times(1)).info("Registry authentication is skipped.");
+        verify(log, times(0)).info("Saving container images is skipped.");
     }
 
     @Test
@@ -104,8 +104,8 @@ public class SaveMojoTest extends AbstractMojoTest {
         when(build.getDirectory()).thenReturn("target");
 
         Assertions.assertDoesNotThrow(saveMojo::execute);
-        verify(log, Mockito.times(1)).warn(Mockito.eq("No Containerfile was found at " + targetLocationAsString + File.separator + "Containerfile, however this will be ignored due to current plugin configuration."));
-        verify(log, Mockito.times(1)).warn(Mockito.eq("Skipping save of container image with name sample. Configuration is not valid for this module!"));
+        verify(log, Mockito.times(1)).warn("No Containerfile was found at " + targetLocationAsString + File.separator + "Containerfile, however this will be ignored due to current plugin configuration.");
+        verify(log, Mockito.times(1)).warn("Skipping save of container image with name sample. Configuration is not valid for this module!");
     }
 
     @Test
@@ -126,9 +126,9 @@ public class SaveMojoTest extends AbstractMojoTest {
 
         Assertions.assertDoesNotThrow(saveMojo::execute);
 
-        verify(log, times(1)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, times(0)).info(Mockito.eq("Saving container images is skipped."));
-        verify(podmanExecutorService, times(1)).save(eq(target.resolve("sample_1_0_0.tar.gz").normalize().toAbsolutePath().toString()), eq("registry.example.com/sample:1.0.0"));
+        verify(log, times(1)).info("Registry authentication is skipped.");
+        verify(log, times(0)).info("Saving container images is skipped.");
+        verify(podmanExecutorService, times(1)).save(target.resolve("sample_1_0_0.tar.gz").normalize().toAbsolutePath().toString(), "registry.example.com/sample:1.0.0");
     }
 
     @Test
@@ -149,9 +149,9 @@ public class SaveMojoTest extends AbstractMojoTest {
 
         Assertions.assertDoesNotThrow(saveMojo::execute);
 
-        verify(log, times(1)).info(Mockito.eq("Registry authentication is skipped."));
-        verify(log, times(0)).info(Mockito.eq("Saving container images is skipped."));
-        verify(podmanExecutorService, times(1)).save(eq(target.resolve("sample_1_0_0.tar.gz").normalize().toAbsolutePath().toString()), eq("sample:1.0.0"));
+        verify(log, times(1)).info("Registry authentication is skipped.");
+        verify(log, times(0)).info("Saving container images is skipped.");
+        verify(podmanExecutorService, times(1)).save(target.resolve("sample_1_0_0.tar.gz").normalize().toAbsolutePath().toString(), "sample:1.0.0");
     }
 
     @Test
@@ -173,11 +173,11 @@ public class SaveMojoTest extends AbstractMojoTest {
         saveMojo.execute();
 
         // Verify logging
-        verify(log, times(1)).info(Mockito.eq("Exporting container images to local disk ..."));
-        verify(log, times(1)).warn(Mockito.eq("Detected multistage Containerfile, but no custom image names have been specified. Falling back to exporting final image."));
-        verify(log, times(1)).info(Mockito.eq("Exporting image sample:1.0.0 to " + target.resolve("sample_1_0_0.tar.gz").normalize().toFile().getAbsolutePath()));
-        verify(podmanExecutorService, times(1)).save(eq(target.resolve("sample_1_0_0.tar.gz").normalize().toAbsolutePath().toString()), eq("registry.example.com/sample:1.0.0"));
-        verify(log, times(1)).info(Mockito.eq("Container images exported successfully."));
+        verify(log, times(1)).info("Exporting container images to local disk ...");
+        verify(log, times(1)).warn("Detected multistage Containerfile, but no custom image names have been specified. Falling back to exporting final image.");
+        verify(log, times(1)).info("Exporting image sample:1.0.0 to " + target.resolve("sample_1_0_0.tar.gz").normalize().toFile().getAbsolutePath());
+        verify(podmanExecutorService, times(1)).save(target.resolve("sample_1_0_0.tar.gz").normalize().toAbsolutePath().toString(), "registry.example.com/sample:1.0.0");
+        verify(log, times(1)).info("Container images exported successfully.");
     }
 
     @Test
@@ -202,13 +202,13 @@ public class SaveMojoTest extends AbstractMojoTest {
         saveMojo.execute();
 
         // Verify logging
-        verify(log, times(1)).info(Mockito.eq("Exporting container images to local disk ..."));
-        verify(log, times(0)).warn(Mockito.eq("Detected multistage Containerfile, but no custom image names have been specified. Falling back to exporting final image."));
-        verify(log, times(1)).info(Mockito.eq("Exporting image image-name-number-1:0.2.1 to " + target.resolve("image_name_number_1_0_2_1.tar.gz").normalize().toFile().getAbsolutePath()));
-        verify(podmanExecutorService, times(1)).save(eq(target.resolve("image_name_number_1_0_2_1.tar.gz").normalize().toFile().getAbsolutePath()), eq("registry.example.com/image-name-number-1:0.2.1"));
-        verify(log, times(1)).info(Mockito.eq("Exporting image image-name-number-2:0.2.1 to " + target.resolve("image_name_number_2_0_2_1.tar.gz").normalize().toFile().getAbsolutePath()));
-        verify(podmanExecutorService, times(1)).save(eq(target.resolve("image_name_number_2_0_2_1.tar.gz").normalize().toFile().getAbsolutePath()), eq("registry.example.com/image-name-number-2:0.2.1"));
-        verify(log, times(1)).info(Mockito.eq("Container images exported successfully."));
+        verify(log, times(1)).info("Exporting container images to local disk ...");
+        verify(log, times(0)).warn("Detected multistage Containerfile, but no custom image names have been specified. Falling back to exporting final image.");
+        verify(log, times(1)).info("Exporting image image-name-number-1:0.2.1 to " + target.resolve("image_name_number_1_0_2_1.tar.gz").normalize().toFile().getAbsolutePath());
+        verify(podmanExecutorService, times(1)).save(target.resolve("image_name_number_1_0_2_1.tar.gz").normalize().toFile().getAbsolutePath(), "registry.example.com/image-name-number-1:0.2.1");
+        verify(log, times(1)).info("Exporting image image-name-number-2:0.2.1 to " + target.resolve("image_name_number_2_0_2_1.tar.gz").normalize().toFile().getAbsolutePath());
+        verify(podmanExecutorService, times(1)).save(target.resolve("image_name_number_2_0_2_1.tar.gz").normalize().toFile().getAbsolutePath(), "registry.example.com/image-name-number-2:0.2.1");
+        verify(log, times(1)).info("Container images exported successfully.");
     }
 
     private void configureMojo(SingleImageConfiguration image, boolean skipAll, boolean skipSave, String pushRegistry, boolean failOnMissingContainerfile) {

--- a/src/test/java/nl/lexemmens/podman/service/AuthenticationServiceTest.java
+++ b/src/test/java/nl/lexemmens/podman/service/AuthenticationServiceTest.java
@@ -1,6 +1,5 @@
 package nl.lexemmens.podman.service;
 
-import nl.lexemmens.podman.enumeration.TlsVerify;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.settings.Proxy;
@@ -37,7 +36,6 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -123,8 +121,8 @@ public class AuthenticationServiceTest {
         AuthenticationService authenticationService = new AuthenticationService(log, podmanExecutorService, settings, settingsDecrypter);
         Assertions.assertThrows(MojoExecutionException.class, () -> authenticationService.authenticate(null));
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Checking authentication status..."));
-        verify(log, Mockito.times(1)).error(Mockito.eq("No registries have been configured but authentication is not skipped. If you want to skip authentication, run again with 'podman.skip.auth' set to true"));
+        verify(log, Mockito.times(1)).info("Checking authentication status...");
+        verify(log, Mockito.times(1)).error("No registries have been configured but authentication is not skipped. If you want to skip authentication, run again with 'podman.skip.auth' set to true");
     }
 
     @Test
@@ -132,8 +130,8 @@ public class AuthenticationServiceTest {
         AuthenticationService authenticationService = new AuthenticationService(log, podmanExecutorService, settings, settingsDecrypter);
         Assertions.assertThrows(MojoExecutionException.class, () -> authenticationService.authenticate(new String[]{}));
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Checking authentication status..."));
-        verify(log, Mockito.times(1)).error(Mockito.eq("No registries have been configured but authentication is not skipped. If you want to skip authentication, run again with 'podman.skip.auth' set to true"));
+        verify(log, Mockito.times(1)).info("Checking authentication status...");
+        verify(log, Mockito.times(1)).error("No registries have been configured but authentication is not skipped. If you want to skip authentication, run again with 'podman.skip.auth' set to true");
     }
 
     @Test
@@ -147,9 +145,9 @@ public class AuthenticationServiceTest {
         AuthenticationService authenticationService = new AuthenticationService(log, podmanExecutorService, settings, settingsDecrypter);
         Assertions.assertThrows(MojoExecutionException.class, () -> authenticationService.authenticate(registries));
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Checking authentication status..."));
-        verify(log, Mockito.times(1)).info(Mockito.eq("Authentication file not (yet) present. Authenticating..."));
-        verify(log, Mockito.times(0)).error(Mockito.eq("No registries have been configured but authentication is not skipped. If you want to skip authentication, run again with 'podman.skip.auth' set to true"));
+        verify(log, Mockito.times(1)).info("Checking authentication status...");
+        verify(log, Mockito.times(1)).info("Authentication file not (yet) present. Authenticating...");
+        verify(log, Mockito.times(0)).error("No registries have been configured but authentication is not skipped. If you want to skip authentication, run again with 'podman.skip.auth' set to true");
     }
 
     @Test
@@ -163,7 +161,7 @@ public class AuthenticationServiceTest {
 
         List<Server> serverList = Collections.singletonList(server);
 
-        when(settings.getServer(eq(registryName))).thenReturn(server);
+        when(settings.getServer(registryName)).thenReturn(server);
         when(settings.getServers()).thenReturn(serverList);
         when(settings.getProxies()).thenReturn(new ArrayList<>());
         when(settingsDecrypter.decrypt(isA(SettingsDecryptionRequest.class))).thenReturn(createSettingsDecryptionResult(serverList, new ArrayList<>()));
@@ -177,9 +175,9 @@ public class AuthenticationServiceTest {
         AuthenticationService authenticationService = new AuthenticationService(log, podmanExecutorService, settings, settingsDecrypter);
         authenticationService.authenticate(registries);
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Checking authentication status..."));
-        verify(log, Mockito.times(1)).info(Mockito.eq("Authentication file not (yet) present. Authenticating..."));
-        verify(log, Mockito.times(0)).error(Mockito.eq("No registries have been configured but authentication is not skipped. If you want to skip authentication, run again with 'podman.skip.auth' set to true"));
+        verify(log, Mockito.times(1)).info("Checking authentication status...");
+        verify(log, Mockito.times(1)).info("Authentication file not (yet) present. Authenticating...");
+        verify(log, Mockito.times(0)).error("No registries have been configured but authentication is not skipped. If you want to skip authentication, run again with 'podman.skip.auth' set to true");
         verify(podmanExecutorService, times(1)).login(registryName, "username", "password");
     }
 
@@ -194,8 +192,8 @@ public class AuthenticationServiceTest {
         AuthenticationService authenticationService = new AuthenticationService(log, podmanExecutorService, settings, settingsDecrypter);
         authenticationService.authenticate(new String[]{"unknown-registry.example.com"});
 
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Found custom registry authentication file at: " + customAuthFile));
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Checking unauthenticated registries..."));
+        verify(log, Mockito.times(1)).debug("Found custom registry authentication file at: " + customAuthFile);
+        verify(log, Mockito.times(1)).debug("Checking unauthenticated registries...");
     }
 
     @Test
@@ -215,7 +213,7 @@ public class AuthenticationServiceTest {
 
         List<Server> serverList = Collections.singletonList(server);
 
-        when(settings.getServer(eq(registryName))).thenReturn(server);
+        when(settings.getServer(registryName)).thenReturn(server);
         when(settings.getServers()).thenReturn(serverList);
         when(settings.getProxies()).thenReturn(new ArrayList<>());
         when(settingsDecrypter.decrypt(isA(SettingsDecryptionRequest.class))).thenReturn(createSettingsDecryptionResult(serverList, new ArrayList<>()));
@@ -223,9 +221,9 @@ public class AuthenticationServiceTest {
         AuthenticationService authenticationService = new AuthenticationService(log, podmanExecutorService, settings, settingsDecrypter);
         authenticationService.authenticate(new String[]{registryName});
 
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Found custom registry authentication file at: " + customAuthFile));
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Checking unauthenticated registries..."));
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Authenticating not-present-registry.example.com"));
+        verify(log, Mockito.times(1)).debug("Found custom registry authentication file at: " + customAuthFile);
+        verify(log, Mockito.times(1)).debug("Checking unauthenticated registries...");
+        verify(log, Mockito.times(1)).debug("Authenticating not-present-registry.example.com");
     }
 
     @Test
@@ -239,8 +237,8 @@ public class AuthenticationServiceTest {
         AuthenticationService authenticationService = new AuthenticationService(log, podmanExecutorService, settings, settingsDecrypter);
         Assertions.assertThrows(MojoExecutionException.class, () -> authenticationService.authenticate(new String[]{"unknown-registry.example.com"}));
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Checking authentication status..."));
-        verify(log, Mockito.times(1)).debug(Mockito.eq("No authenticated registries were found."));
+        verify(log, Mockito.times(1)).info("Checking authentication status...");
+        verify(log, Mockito.times(1)).debug("No authenticated registries were found.");
     }
 
     @Test
@@ -252,8 +250,8 @@ public class AuthenticationServiceTest {
         AuthenticationService authenticationService = new AuthenticationService(log, podmanExecutorService, settings, settingsDecrypter);
         authenticationService.authenticate(new String[]{"unknown-registry.example.com"});
 
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Found default registry authentication file at: " + customAuthFile));
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Checking unauthenticated registries..."));
+        verify(log, Mockito.times(1)).debug("Found default registry authentication file at: " + customAuthFile);
+        verify(log, Mockito.times(1)).debug("Checking unauthenticated registries...");
     }
 
     @Test
@@ -269,8 +267,8 @@ public class AuthenticationServiceTest {
         AuthenticationService authenticationService = new AuthenticationService(log, podmanExecutorService, settings, settingsDecrypter);
         authenticationService.authenticate(new String[]{"unknown-registry.example.com"});
 
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Found Docker registry authentication file at: " + dockerConfigFile));
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Checking unauthenticated registries..."));
+        verify(log, Mockito.times(1)).debug("Found Docker registry authentication file at: " + dockerConfigFile);
+        verify(log, Mockito.times(1)).debug("Checking unauthenticated registries...");
 
         // Clean up the temporary docker config file
         Files.deleteIfExists(dockerConfigFile);

--- a/src/test/java/nl/lexemmens/podman/service/BuildahExecutorServiceTest.java
+++ b/src/test/java/nl/lexemmens/podman/service/BuildahExecutorServiceTest.java
@@ -50,7 +50,7 @@ public class BuildahExecutorServiceTest {
         BuildahExecutorService buildahExecutorService = new BuildahExecutorService(log, podmanConfig, delegate);
         buildahExecutorService.cleanupLocalContainerStorage();
 
-        verify(log, Mockito.times(1)).info(Mockito.eq("Podman root storage location is set to its defaults. Not cleaning up this storage location."));
+        verify(log, Mockito.times(1)).info("Podman root storage location is set to its defaults. Not cleaning up this storage location.");
         assertNull(delegate.getCommandAsString());
     }
 
@@ -69,7 +69,7 @@ public class BuildahExecutorServiceTest {
         BuildahExecutorService buildahExecutorService = new BuildahExecutorService(log, podmanConfig, delegate);
         buildahExecutorService.cleanupLocalContainerStorage();
 
-        verify(log, Mockito.times(0)).info(Mockito.eq("Podman root storage location is set to its defaults. Not cleaning up this storage location."));
+        verify(log, Mockito.times(0)).info("Podman root storage location is set to its defaults. Not cleaning up this storage location.");
         assertEquals(expectedCommand, delegate.getCommandAsString());
     }
 

--- a/src/test/java/nl/lexemmens/podman/service/ContainerfileDecoratorTest.java
+++ b/src/test/java/nl/lexemmens/podman/service/ContainerfileDecoratorTest.java
@@ -71,7 +71,7 @@ public class ContainerfileDecoratorTest {
                 .build();
         Assertions.assertThrows(MojoExecutionException.class, () -> containerfileDecorator.decorateContainerfile(image));
 
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Filtering Containerfile. Source: " + image.getBuild().getSourceContainerFileDir() + ", target: " + image.getBuild().getTargetContainerFile()));
+        verify(log, Mockito.times(1)).debug("Filtering Containerfile. Source: " + image.getBuild().getSourceContainerFileDir() + ", target: " + image.getBuild().getTargetContainerFile());
         verify(log, Mockito.times(1)).error(Mockito.eq("Failed to filter Containerfile! Some exception message!"), isA(MavenFilteringException.class));
     }
 
@@ -86,8 +86,8 @@ public class ContainerfileDecoratorTest {
                 .build();
         Assertions.assertDoesNotThrow(() -> containerfileDecorator.decorateContainerfile(image));
 
-        verify(log, Mockito.times(1)).debug(Mockito.eq("No labels to add to the Containerfile"));
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Filtering Containerfile. Source: " + image.getBuild().getSourceContainerFileDir() + ", target: " + image.getBuild().getTargetContainerFile()));
+        verify(log, Mockito.times(1)).debug("No labels to add to the Containerfile");
+        verify(log, Mockito.times(1)).debug("Filtering Containerfile. Source: " + image.getBuild().getSourceContainerFileDir() + ", target: " + image.getBuild().getTargetContainerFile());
     }
 
     @Test
@@ -106,7 +106,7 @@ public class ContainerfileDecoratorTest {
                 .build();
         Assertions.assertDoesNotThrow(() -> containerfileDecorator.decorateContainerfile(image));
 
-        verify(log, Mockito.times(1)).debug(Mockito.eq("Filtering Containerfile. Source: " + image.getBuild().getSourceContainerFileDir() + ", target: " + image.getBuild().getTargetContainerFile()));
+        verify(log, Mockito.times(1)).debug("Filtering Containerfile. Source: " + image.getBuild().getSourceContainerFileDir() + ", target: " + image.getBuild().getTargetContainerFile());
 
         List<String> collect = Files.lines(Paths.get("target/podman-test/Containerfile")).collect(Collectors.toList());
         String lastLine = collect.get(1);

--- a/src/test/resources/push-multistage/container-catalog.txt
+++ b/src/test/resources/push-multistage/container-catalog.txt
@@ -1,0 +1,3 @@
+[containers]
+registry.example.com/image-name-number-1:0.2.1
+registry.example.com/image-name-number-2:0.2.1

--- a/src/test/resources/push/container-catalog.txt
+++ b/src/test/resources/push/container-catalog.txt
@@ -1,0 +1,2 @@
+[containers]
+registry.example.com/sample:1.0.0


### PR DESCRIPTION
This fixes the PushMojo for deployment of multistage images. There was an issue that the PushMojo tried to built a list of images to deploy using the specified input parameters. However, in case that there was no actual image the PushMojo still tried to deploy it, resulting in a build error.

Since information is not retained between plugin goals, make the push goal use the container-catalog file for deployment of container images.

Some refactoring has been done for both the Copy and Push mojos, since some logic is shared between the mojos (both mojos try to upload stuff).

The skipCatalog flas is still available, only it will now be used for skipping the upload of the container-catalog file.

/cc @basvandenbrink @lexemmens 