### PR TITLE
Upgrade dependency versions and add build arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## Changelog
+### 1.13.0 (05-04-2022)
+#### Improvements
+* ([#59](https://github.com/lexemmens/podman-maven-plugin/issues/59) - Support for build arguments)
+
+#### Bugs
+* ([#74](https://github.com/lexemmens/podman-maven-plugin/issues/74) - Fixed cataloguing of artifacts when catloguing is skipped of no valid images are present)
+
 ### 1.12.0 (21-02-2023)
 #### Improvements
 * ([#69](https://github.com/lexemmens/podman-maven-plugin/issues/69)) - Add SELinux support when building container images (RHEL8/CentOS8)

--- a/docs/modules/ROOT/pages/goals/build.adoc
+++ b/docs/modules/ROOT/pages/goals/build.adoc
@@ -93,6 +93,15 @@ When this option is specified _and_ `pullAlways` is also specified, builds will 
 |<<labels,labels>>
 |A collection of labels to add to this image. They are specified in the typical maven property format.
 
+|<<args,args>>
+|Specifies one or more build arguments and their value, which will be interpolated in instructions read from the
+Containerfiles in the same way that environment variables are, but which will not be added to environment variable
+list in the resulting image’s configuration.
+
+**Syntax**: `<arg>value</arg>`
+
+**See**: https://docs.podman.io/en/latest/markdown/podman-build.1.html#build-arg-arg-value
+
 |tagWithMavenProjectVersion
 |When set to `true`, the resulting container image will be tagged with the current version of the Maven project.
 
@@ -133,6 +142,10 @@ Supported values are:
                 </tags>
                 <createLatestTag>true</createLatestTag>
                 <format>OCI</format>
+                <args>
+                    <buildArg1>buildArgValue1</buildArg1>
+                    <buildArg2>buildArgValue2</buildArg2>
+                </args>
             </build>
         </image>
     </images>
@@ -163,6 +176,17 @@ WARNING: Please be advised that you can only configure one run directory for pod
 Labels are a mechanism for applying metadata to container images. Labels can be used to order images. A label is a key-value pair, stored as a string. You can specify multiple labels for an object, but each key-value pair must be unique within an object. If the same key is given multiple values, the most-recently-written value overwrites all previous values.
 
 NOTE: As of version 1.7.1 label values are always stored between double quotes to allow values with spaces.
+
+=== Build arguments
+:navtitle: Build Arguments
+[#args]
+
+Specifies one or more build arguments and their value, which will be interpolated in instructions read from the
+Containerfiles in the same way that environment variables are, but which will not be added to environment variable
+list in the resulting image’s configuration.
+
+Build arguments can also be specified via System Properties, using the syntax: `podman.buildArg.exampleBuildArgument=buildArgumentValue`. Do note that System Properties are global and take precedence over the arguments that are configured
+in the build configuration for each image.
 
 === Key format recommendations
 [#keyformatrecommendations]

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,19 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.0</version>
+            <version>3.7.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -118,25 +130,25 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.1</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.1</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.1</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.8.0</version>
+            <version>5.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -148,7 +160,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.8.0</version>
+            <version>5.1.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -156,7 +168,7 @@
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.9.1</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -174,39 +186,70 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.10.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.7.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.1</version>
+                    <version>3.0.0-M9</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>3.0.0-M9</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>3.0.0.M7</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.5.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.2.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.5.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-metadata</artifactId>
+                    <version>2.1.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.8</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.13</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -214,7 +257,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.0</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
@@ -230,7 +272,6 @@
             <plugin>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-component-metadata</artifactId>
-                <version>2.1.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -251,7 +292,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
                 <executions>
                     <execution>
                         <goals>
@@ -271,16 +311,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
             </plugin>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
                 <executions>
                     <execution>
                         <id>default-deploy</id>
@@ -294,7 +331,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <localCheckout>true</localCheckout>
                     <pushChanges>false</pushChanges>
@@ -305,19 +341,18 @@
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
                         <artifactId>maven-scm-api</artifactId>
-                        <version>1.11.2</version>
+                        <version>2.0.0.M3</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
                         <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.11.2</version>
+                        <version>2.0.0.M3</version>
                     </dependency>
                 </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -328,7 +363,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -341,7 +375,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
                 <configuration>
                     <source>8</source>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -110,13 +110,13 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.1.0</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-settings</artifactId>
-            <version>3.1.0</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/nl/lexemmens/podman/command/podman/AbstractPodmanCommand.java
+++ b/src/main/java/nl/lexemmens/podman/command/podman/AbstractPodmanCommand.java
@@ -21,8 +21,6 @@ public abstract class AbstractPodmanCommand extends AbstractCommand {
     private static final String BASE_COMMAND = "podman";
     private static final String ROOT_CMD = "--root=";
     private static final String RUNROOT_CMD = "--runroot=";
-    private static final String CGROUP_MANAGER = "--cgroup-manager";
-
     private final boolean redirectError;
     private final List<String> command;
 

--- a/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
@@ -30,7 +30,7 @@ public abstract class AbstractImageBuildConfiguration {
      * named stages.
      */
     protected static final Pattern MULTISTAGE_CONTAINERFILE_REGEX = Pattern.compile(
-        "(FROM\\s[a-zA-Z0-9./:_\\-${}]{0,255}\\s)([ASas]{2}\\s)([a-zA-Z0-9./:_\\-]{1,128})"
+            "(FROM\\s[a-zA-Z0-9./:_\\-${}]{0,255}\\s)([ASas]{2}\\s)([a-zA-Z0-9./:_\\-]{1,128})"
     );
 
     /**
@@ -82,6 +82,11 @@ public abstract class AbstractImageBuildConfiguration {
     @Parameter
     protected String containerFile;
 
+    /**
+     * Collection of build arguments to use during Podman build
+     */
+    @Parameter
+    private Map<String, String> args;
 
     /**
      * Specify any labels to be applied to the image
@@ -202,6 +207,10 @@ public abstract class AbstractImageBuildConfiguration {
 
         if (containerFileDir == null) {
             containerFileDir = project.getBasedir();
+        }
+
+        if(args == null) {
+            args = new HashMap<>();
         }
     }
 
@@ -480,4 +489,21 @@ public abstract class AbstractImageBuildConfiguration {
         this.containerFileDir = containerFileDir;
     }
 
+    /**
+     * Retrieves a collection of build arguments to provide to podman build using --build-arg
+     *
+     * @return A collection of build arguments to provide to podman build
+     */
+    public Map<String, String> getArgs() {
+        return args;
+    }
+
+    /**
+     * The build arguments to set for use during Podman build
+     *
+     * @param args The arguments to set
+     */
+    public void setArgs(Map<String, String> args) {
+        this.args = args;
+    }
 }

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -76,6 +76,8 @@ public class PodmanExecutorService {
             builder = builder.setPullAllways(pullAlwaysOptional.get());
         }
 
+        builder.addBuildArgs(image.getBuild().getArgs());
+
         return builder.build().execute();
     }
 

--- a/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/BuildMojoTest.java
@@ -382,7 +382,6 @@ public class BuildMojoTest extends AbstractMojoTest {
         when(mavenProject.getBuild()).thenReturn(build);
         when(build.getDirectory()).thenReturn("target");
         when(serviceHubFactory.createServiceHub(isA(Log.class), isA(MavenProject.class), isA(MavenFileFilter.class), isA(PodmanConfiguration.class), isA(SkopeoConfiguration.class), isA(Settings.class), isA(SettingsDecrypter.class), isA(MavenProjectHelper.class))).thenReturn(serviceHub);
-        when(serviceHub.getMavenProjectHelper()).thenReturn(mavenProjectHelper);
 
         Assertions.assertDoesNotThrow(buildMojo::execute);
         verify(log, Mockito.times(1)).warn("No Containerfile was found at " + targetLocationAsString + File.separator + "Containerfile, however this will be ignored due to current plugin configuration.");

--- a/src/test/java/nl/lexemmens/podman/config/image/single/TestSingleImageConfigurationBuilder.java
+++ b/src/test/java/nl/lexemmens/podman/config/image/single/TestSingleImageConfigurationBuilder.java
@@ -69,6 +69,11 @@ public class TestSingleImageConfigurationBuilder {
         return this;
     }
 
+    public TestSingleImageConfigurationBuilder setBuildArgs(Map<String, String> args) {
+        image.getBuild().setArgs(args);
+        return this;
+    }
+
     public TestSingleImageConfigurationBuilder setUseMavenProjectVersion(boolean useMavenProjectVersion) {
         image.getBuild().setTagWithMavenProjectVersion(useMavenProjectVersion);
         return this;


### PR DESCRIPTION
This PR updates version numbers and adds a long awaited option to configure build-arguments for Podman Build.

This also fixes #59 and this also fixes #74

