### PR TITLE
Skip copy goal if no container catalog artifact is found

### DIFF
--- a/src/main/java/nl/lexemmens/podman/AbstractCatalogSupport.java
+++ b/src/main/java/nl/lexemmens/podman/AbstractCatalogSupport.java
@@ -17,6 +17,7 @@ import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.transfer.ArtifactNotFoundException;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,8 +64,7 @@ public abstract class AbstractCatalogSupport extends AbstractPodmanMojo {
 
             ArtifactResult artifactResult = repositorySystem.resolveArtifact(repositorySystemSession, artifactRequest);
             if (artifactResult.isMissing()) {
-                throw new MojoExecutionException("Cannot find container catalog. All repositories were successfully " +
-                        "queried, but no such artifact was returned.");
+                return Collections.emptyList();
             }
             if (artifactResult.isResolved()) {
                 return readCatalogContent(Paths.get(artifactResult.getArtifact().getFile().toURI()), false);
@@ -73,6 +73,9 @@ public abstract class AbstractCatalogSupport extends AbstractPodmanMojo {
             }
 
         } catch (ArtifactResolutionException e) {
+            if (e.getCause() instanceof ArtifactNotFoundException) {
+                return Collections.emptyList();
+            }
             throw new MojoExecutionException("Failed retrieving container catalog file", e);
         }
     }

--- a/src/main/java/nl/lexemmens/podman/CopyMojo.java
+++ b/src/main/java/nl/lexemmens/podman/CopyMojo.java
@@ -55,17 +55,22 @@ public class CopyMojo extends AbstractCatalogSupport {
         File tempRepo = tempSession.repo;
 
         List<String> cataloguedImages = readRemoteCatalog(tempSession.session);
-        Map<String, String> transformedImages = performTransformation(cataloguedImages);
+        if (cataloguedImages.isEmpty()) {
+            getLog().info("Not copying container images, because no container-catalog.txt artifact was " +
+                "found.");
+        } else {
+            Map<String, String> transformedImages = performTransformation(cataloguedImages);
 
-        for (Map.Entry<String, String> imageEntry : transformedImages.entrySet()) {
-            copyImage(hub, imageEntry.getKey(), imageEntry.getValue());
-        }
+            for (Map.Entry<String, String> imageEntry : transformedImages.entrySet()) {
+                copyImage(hub, imageEntry.getKey(), imageEntry.getValue());
+            }
 
-        if (skopeo.getCopy().getDisableLocal() && tempRepo != null) {
-            try {
-                FileUtils.deleteDirectory(tempRepo);
-            } catch (IOException e) {
-                getLog().warn("Failed to cleanup temporary repository directory: " + tempRepo);
+            if (skopeo.getCopy().getDisableLocal() && tempRepo != null) {
+                try {
+                    FileUtils.deleteDirectory(tempRepo);
+                } catch (IOException e) {
+                    getLog().warn("Failed to cleanup temporary repository directory: " + tempRepo);
+                }
             }
         }
     }

--- a/src/test/java/nl/lexemmens/podman/CopyMojoTest.java
+++ b/src/test/java/nl/lexemmens/podman/CopyMojoTest.java
@@ -181,15 +181,17 @@ public class CopyMojoTest extends AbstractMojoTest {
     public void testWithCatalogFile() throws MojoExecutionException {
         configureMojo(false, false, true, null, new String[]{}, "stage", "release", null, false, false, false);
         assertDoesNotThrow(copyMojo::execute);
-        verify(skopeoExecutorService, times(0)).copy(anyString(), anyString());
+        verify(skopeoExecutorService, times(1)).copy("dep1.stage.registry.example.com/foo/bar:0.1.0", "dep1.release.registry.example.com/foo/bar:0.1.0");
+        verify(skopeoExecutorService, times(1)).copy("dep2.stage.registry.example.com/project/product:2.1.3", "dep2.release.registry.example.com/project/product:2.1.3");
     }
 
     @Test
-    public void testSkipCopyNoCatalogFile() throws ArtifactResolutionException {
+    public void testSkipCopyNoCatalogFile() throws ArtifactResolutionException, MojoExecutionException {
         configureMojo(false, false, true, null, new String[]{}, "stage", "release", null, false, false, false);
         when(copyMojo.repositorySystem.resolveArtifact(any(RepositorySystemSession.class), any(ArtifactRequest.class)))
             .thenThrow(new ArtifactResolutionException(null, null, new ArtifactNotFoundException(null, null)));
         assertDoesNotThrow(copyMojo::execute);
+        verify(skopeoExecutorService, times(0)).copy(anyString(), anyString());
     }
 
     private static void cleanDir(Path dir) throws IOException {


### PR DESCRIPTION
Currently, when executing the copy goal on projects (or modules?) that don't build container images, the goal fails. This pull request fixes this. The copy goal execution will be skipped when no container-catalog.txt file can be found.

This pull request aligns the behaviour of the copy goal with other goals.