### PR TITLE
Added an option to allow pom.xml to specify podman --platform argument

### DIFF
--- a/docs/modules/ROOT/pages/goals/build.adoc
+++ b/docs/modules/ROOT/pages/goals/build.adoc
@@ -39,6 +39,16 @@ Note: You can also override the default value of layers by setting the BUILDAH_L
 
 **See**: https://docs.podman.io/en/latest/markdown/podman-build.1.html
 
+|platform
+|Specifies the platform to be passed to Podman to control the operating system, architecture and variants of the resulting image.
+
+**Default value is**: `null` (not specified and Podman will build a container that targets the system doing the container build)
+
+**Example value for linux x86_64 is**: linux/amd64
+
+**Example value for linux aarch64 is**: linux/arm64
+
+**See (--platform)**: https://docs.podman.io/en/latest/markdown/podman-build.1.html
 |noCache
 |Do not use existing cached images for the container build. Build from the start with a new set of cached layers.
 

--- a/src/main/java/nl/lexemmens/podman/command/podman/PodmanBuildCommand.java
+++ b/src/main/java/nl/lexemmens/podman/command/podman/PodmanBuildCommand.java
@@ -27,6 +27,7 @@ public class PodmanBuildCommand extends AbstractPodmanCommand {
     private static final String PULL_ALWAYS_CMD = "--pull-always";
     private static final String NO_CACHE_CMD = "--no-cache";
     private static final String BUILD_ARG_CMD = "--build-arg";
+    private static final String PLATFORM_CMD = "--platform";
     private static final String SUBCOMMAND = "build";
 
     private PodmanBuildCommand(Log log, PodmanConfiguration podmanConfig, CommandExecutorDelegate delegate) {
@@ -137,6 +138,17 @@ public class PodmanBuildCommand extends AbstractPodmanCommand {
             return this;
         }
 
+        /**
+         * Sets the platform for the resulting image rather using the default of the build system
+         *
+         * @param platform A valid combination of GO OS and GO ARCH for example linux/arm64 (https://golang.org/doc/install/source#environment)
+         * @return This builder instance
+         */
+        public Builder setPlatform(String platform){
+            command.withOption(PLATFORM_CMD, platform);
+            return this;
+        }
+        
         public Builder addBuildArgs(Map<String, String> args) {
             Map<String, String> allBuildArgs = new HashMap<>(args);
             allBuildArgs.putAll(getBuildArgsFromSystem());

--- a/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
@@ -148,6 +148,15 @@ public abstract class AbstractImageBuildConfiguration {
     protected Boolean layers;
 
     /**
+     * Specify the resulting image platform by being passed to the "--platform" option of podman.
+     * <p>
+     *
+     * @see "https://docs.podman.io/en/latest/markdown/podman-build.1.html"
+     */
+    @Parameter
+    protected String platform;
+
+    /**
      * Will be set when this class is validated using the #initAndValidate() method
      */
     protected File outputDirectory;
@@ -323,6 +332,15 @@ public abstract class AbstractImageBuildConfiguration {
     }
 
     /**
+     * Returns the platform that Podman should be told to build for.
+     *
+     * @return When set, a string in the format of GO OS/GO ARCH (because GO is the language of Podman) for example: linux/arm64
+     */
+    public Optional<String> getPlatform(){
+        return Optional.ofNullable(platform);
+    }
+
+    /**
      * Returns a boolean indicating whether this configuration is valid
      *
      * @return true if this configuration is valid. False otherwise.
@@ -377,6 +395,15 @@ public abstract class AbstractImageBuildConfiguration {
      */
     public void setLayers(Boolean layers) {
         this.layers = layers;
+    }
+
+    /**
+     * Used to set the platform to be passed to Podman when building the image.
+     *
+     * @param platform String in the format of GO OS/GO ARCH (because GO is the language of Podman) for example: linux/arm64
+     */
+    public void setPlatform(String platform){
+        this.platform = platform;
     }
 
     /**

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -76,6 +76,11 @@ public class PodmanExecutorService {
             builder = builder.setPullAllways(pullAlwaysOptional.get());
         }
 
+        Optional<String> platform = image.getBuild().getPlatform();
+        if (platform.isPresent()) {
+            builder = builder.setPlatform(platform.get());
+        }
+        
         builder.addBuildArgs(image.getBuild().getArgs());
 
         return builder.build().execute();

--- a/src/test/java/nl/lexemmens/podman/config/image/single/TestSingleImageConfigurationBuilder.java
+++ b/src/test/java/nl/lexemmens/podman/config/image/single/TestSingleImageConfigurationBuilder.java
@@ -27,6 +27,11 @@ public class TestSingleImageConfigurationBuilder {
         return this;
     }
 
+    public TestSingleImageConfigurationBuilder setPlatform(String platform){
+        image.getBuild().setPlatform(platform);
+        return this;
+    }
+
     public TestSingleImageConfigurationBuilder setNoCache(boolean noCache) {
         image.getBuild().setNoCache(noCache);
         return this;


### PR DESCRIPTION
Creates a new subtag of the `<build>` tag named `<platform>` that allows the user to configure in pom.xml the target platform for the resulting image.

This allows building images for a platform other than the system building the image.