### PR TITLE
Added support to define custom context directory instead of '.' (is still default when omitted)

### DIFF
--- a/src/main/java/nl/lexemmens/podman/command/podman/PodmanBuildCommand.java
+++ b/src/main/java/nl/lexemmens/podman/command/podman/PodmanBuildCommand.java
@@ -96,6 +96,17 @@ public class PodmanBuildCommand extends AbstractPodmanCommand {
         }
 
         /**
+         * Sets the context directory to use
+         * 
+         * @param contextDir the context directory to set
+         * @return This builder instance
+         */
+        public Builder setContextDir(String contextDir) {
+	        command.withOption(contextDir, null);
+	        return this;
+        }
+        
+        /**
          * Sets the Containerfile that should be build
          *
          * @param containerFile The pointer towards the containerfile to use
@@ -196,8 +207,6 @@ public class PodmanBuildCommand extends AbstractPodmanCommand {
          * @return The constructed command
          */
         public Command build() {
-            // Add current directory
-            command.withOption(".", null);
             return command;
         }
 

--- a/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
@@ -39,6 +39,17 @@ public abstract class AbstractImageBuildConfiguration {
     protected static final String DEFAULT_CONTAINERFILE = "Containerfile";
 
     /**
+     * The default context directory
+     */
+    protected static final String DEFAULT_CONTEXT_DIR = ".";
+
+     /**
+     * The context directory to use
+     */
+    @Parameter
+    protected String contextDir;
+    
+    /**
      * Directory containing the Containerfile
      */
     @Parameter
@@ -226,6 +237,10 @@ public abstract class AbstractImageBuildConfiguration {
         if (containerFileDir == null) {
             containerFileDir = project.getBasedir();
         }
+        
+        if (contextDir == null) {
+               contextDir = DEFAULT_CONTEXT_DIR;
+        }
 
         if(args == null) {
             args = new HashMap<>();
@@ -251,6 +266,15 @@ public abstract class AbstractImageBuildConfiguration {
             allTags.add(mavenProjectVersion);
         }
         return allTags;
+    }
+    
+    /**
+    * Returns the context directory path
+     *
+     * @return Returns the context directory path
+     */
+    public Optional<String> getContextDir(){
+        return Optional.ofNullable(contextDir);
     }
 
     /**
@@ -533,6 +557,15 @@ public abstract class AbstractImageBuildConfiguration {
      */
     public void setFormat(ContainerFormat format) {
         this.format = format;
+    }
+    
+    /**
+     * Sets the context directory to use
+     *
+     * @param contextDir The directory to set
+     */
+    public void setContextDir(String contextDir) {
+		this.contextDir = contextDir;
     }
 
     /**

--- a/src/main/java/nl/lexemmens/podman/config/image/batch/BatchImageConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/batch/BatchImageConfiguration.java
@@ -89,6 +89,10 @@ public class BatchImageConfiguration extends AbstractImageConfiguration<BatchIma
 
             buildConfiguration.setTagWithMavenProjectVersion(getBuild().isTagWithMavenProjectVersion());
 
+            if(getBuild().getContextDir().isPresent()) {
+                buildConfiguration.setContextDir(getBuild().getContextDir().get());
+            }
+            
             imageConfiguration.setBuild(buildConfiguration);
             imageConfigurations.add(imageConfiguration);
         }

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -7,6 +7,7 @@ import nl.lexemmens.podman.executor.CommandExecutorDelegate;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
+import java.io.File;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -87,6 +88,11 @@ public class PodmanExecutorService {
         }
 
         builder.addBuildArgs(image.getBuild().getArgs());
+        
+        Optional<String> contextDir = image.getBuild().getContextDir();
+        if (contextDir.isPresent()) {
+            builder = builder.setContextDir(contextDir.get());
+        }
 
         return builder.build().execute();
     }


### PR DESCRIPTION
In Version 1.18.0 there is no possibility to define a custom context directory. The context is appended hard coded as '.' at the end of the build command (method 'PodmanBuildCommand.build()'). Especially when copying files from the host into the image it is often necessary to expand the context to a higher directory.

This change adds the build configuration option "contextDir". If the option is ommited the fallback is still '.'