### PR TITLE
feat: pass user limits `--ulimit=<type>=<hard>:<soft>` into build

### DIFF
--- a/docs/modules/ROOT/pages/goals/build.adoc
+++ b/docs/modules/ROOT/pages/goals/build.adoc
@@ -141,6 +141,16 @@ Supported values are:
 
 **See**: https://docs.podman.io/en/latest/markdown/podman-build.1.html
 
+|ulimits
+|Specifies one or more user limits, such as `nofile` (number of open files), permitted in the build container.
+Necessary, because `podman build` does not pass the current user session's user limits into the build container, breaking, e.g., large Java builds.
+
+**Syntax**: `<type>soft-limit[:hard-limit]</type>`
+
+Type is one of (core cpu data fsize locks memlock msgqueue nice nofile nproc rss rtprio rttime sigpending stack).
+
+**See**: https://docs.podman.io/en/latest/markdown/podman-build.1.html#ulimit-type-soft-limit-hard-limit
+
 |===
 
 .Example configuration

--- a/src/main/java/nl/lexemmens/podman/command/podman/PodmanBuildCommand.java
+++ b/src/main/java/nl/lexemmens/podman/command/podman/PodmanBuildCommand.java
@@ -30,6 +30,8 @@ public class PodmanBuildCommand extends AbstractPodmanCommand {
     private static final String PLATFORM_CMD = "--platform";
     private static final String TARGET_STAGE_CMD = "--target";
     private static final String SUBCOMMAND = "build";
+    private static final String PODMAN_ULIMITS_PREFIX = "podman.buildUlimits.";
+    private static final String ULIMITS_ARG_CMD = "--ulimit";
 
     private PodmanBuildCommand(Log log, PodmanConfiguration podmanConfig, CommandExecutorDelegate delegate) {
         super(log, podmanConfig, delegate, SUBCOMMAND, false);
@@ -149,7 +151,7 @@ public class PodmanBuildCommand extends AbstractPodmanCommand {
             command.withOption(PLATFORM_CMD, platform);
             return this;
         }
-        
+
         /**
          * Sets the platform for the resulting image rather using the default of the build system
          *
@@ -188,6 +190,35 @@ public class PodmanBuildCommand extends AbstractPodmanCommand {
             }
 
             return buildArgsFromSystem;
+        }
+
+        public Builder addUlimitsArgs(Map<String, String> ulimits) {
+            Map<String, String> allUlimitsArgs = new HashMap<>(ulimits);
+            allUlimitsArgs.putAll(getUlimitsFromSystem());
+
+            for (Map.Entry<String, String> ulimit : allUlimitsArgs.entrySet()) {
+                command.withOption(ULIMITS_ARG_CMD, String.format("%s=%s", ulimit.getKey(), ulimit.getValue()));
+            }
+            return this;
+        }
+
+        private Map<String, String> getUlimitsFromSystem() {
+            Map<String, String> buildUlimitsFromSystem = new HashMap<>();
+            Properties properties = System.getProperties();
+
+            for (Object keyObj : properties.keySet()) {
+                String key = (String) keyObj;
+                if (key.startsWith(PODMAN_ULIMITS_PREFIX)) {
+                    String ulimitKey = key.replaceFirst(PODMAN_ULIMITS_PREFIX, "");
+                    String ulimitValue = properties.getProperty(key);
+
+                    if (!isEmpty(ulimitValue)) {
+                        buildUlimitsFromSystem.put(ulimitKey, ulimitValue);
+                    }
+                }
+            }
+
+            return buildUlimitsFromSystem;
         }
 
         /**

--- a/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
+++ b/src/main/java/nl/lexemmens/podman/config/image/AbstractImageBuildConfiguration.java
@@ -89,6 +89,12 @@ public abstract class AbstractImageBuildConfiguration {
     private Map<String, String> args;
 
     /**
+     * Collection of user limits to use during Podman build
+     */
+    @Parameter
+    private Map<String, String> ulimits;
+
+    /**
      * Specify any labels to be applied to the image
      */
     @Parameter
@@ -229,6 +235,9 @@ public abstract class AbstractImageBuildConfiguration {
 
         if(args == null) {
             args = new HashMap<>();
+        }
+        if(ulimits == null) {
+            ulimits = new HashMap<>();
         }
     }
 
@@ -570,4 +579,23 @@ public abstract class AbstractImageBuildConfiguration {
     public void setArgs(Map<String, String> args) {
         this.args = args;
     }
+
+    /**
+     * Retrieves a collection of user limtis  to provide to podman build using --ulimits
+     *
+     * @return A collection of user limits to provide to podman build
+     */
+    public Map<String, String> getUlimits() {
+        return ulimits;
+    }
+
+    /**
+     * The user limits to set for use during Podman build
+     *
+     * @param ulimits The arguments to set
+     */
+    public void setUlimits(Map<String, String> ulimits) {
+        this.ulimits = ulimits;
+    }
+
 }

--- a/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
+++ b/src/main/java/nl/lexemmens/podman/service/PodmanExecutorService.java
@@ -87,6 +87,7 @@ public class PodmanExecutorService {
         }
 
         builder.addBuildArgs(image.getBuild().getArgs());
+        builder.addUlimitsArgs(image.getBuild().getUlimits());
 
         return builder.build().execute();
     }


### PR DESCRIPTION
First, thank you for developing the podman-maven-plugin and making it available to the general public. It has been of extreme use to me since it's release.

When using the plugin to build something large, in my case this has been building `keycloak` in a podman container, the number of open files is much smaller (1024) than in an interactive session (`podman run`). This breaks such large builds.

I tried to align setting the `--ulimits`-flag, paralleling the `--build-args`-flag. Should I break a desired sorting order, please let me know.

Thanks for your consideration and your effort, Cheers, Christopher